### PR TITLE
Enforce coordinator pattern with PreToolUse hooks

### DIFF
--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Hook: PreToolUse - blocks Edit/Write unless in a worktree
+# Main repo has .git as directory, worktree has .git as file
+# Exit code 2 = block, message to stderr
+
+# Check if .git is a directory (main repo) or file (worktree)
+if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  # Main repo - block edits with exit code 2
+  echo "BLOCKED: Cannot edit in main repo. Create worktree first: git worktree add ../worktrees/feature -b feature" >&2
+  exit 2
+fi
+
+# Worktree - allow
+exit 0

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-# Hook: PreToolUse - blocks Edit/Write unless in a worktree
-# Main repo has .git as directory, worktree has .git as file
+# Hook: PreToolUse - blocks heavy tools in main repo
+# Main agent = coordinator only. Work happens in worktrees via background agents.
 # Exit code 2 = block, message to stderr
 
-# Check if .git is a directory (main repo) or file (worktree)
 if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
-  # Main repo - block edits with exit code 2
-  echo "BLOCKED: Cannot edit in main repo. Create worktree first: git worktree add ../worktrees/feature -b feature" >&2
+  echo "BLOCKED: Main agent is coordinator only. Use Task tool to spawn background agent in worktree." >&2
   exit 2
 fi
 

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
 
-# Hook: PreToolUse - blocks heavy tools in main repo
-# Main agent = coordinator only. Work happens in worktrees via background agents.
+# Hook: PreToolUse - enforces coordinator pattern in main repo
+# Main agent can only: Read, Glob, Grep, Task (background only)
 # Exit code 2 = block, message to stderr
 
-if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
-  echo "BLOCKED: Main agent is coordinator only. Use Task tool to spawn background agent in worktree." >&2
-  exit 2
+# Only enforce in main repo (not worktrees)
+if [ ! -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  exit 0
 fi
 
-# Worktree - allow
-exit 0
+# Read tool input from stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Task tool: only allow if run_in_background is true
+if [ "$TOOL_NAME" = "Task" ]; then
+  RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
+  if [ "$RUN_IN_BG" != "true" ]; then
+    echo "BLOCKED: Task must use run_in_background: true. Main agent is coordinator only." >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+# All other matched tools (Edit, Write, Bash, WebFetch, WebSearch) are blocked
+echo "BLOCKED: Main agent is coordinator only. Use Task tool with run_in_background: true." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "enableAllProjectMcpServers": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|Bash|WebFetch|WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/notify-claude-stopped.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|Bash|WebFetch|WebSearch",
+        "matcher": "Edit|Write|Bash|WebFetch|WebSearch|Task",
         "hooks": [
           {
             "type": "command",

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -22,6 +22,9 @@ else
     BUILD_DIR='/tmp/build-test-auto'
 fi
 
+# Ensure required directories exist (not in git, needed at runtime)
+mkdir -p private/logs
+
 # Get iPhone ID early for terminating old app
 export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 IPHONE_ID=$(xcodebuild -scheme RealtimeClaude -showdestinations 2>/dev/null | grep "name:iPhone" | grep -o 'id:[^,]*' | head -1 | cut -d: -f2)

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -2,6 +2,7 @@
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 COMMIT_HASH=$(git rev-parse HEAD)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 AUTOMATED_MARKER="$REPO_ROOT/.test-passed-automated"
 MANUAL_MARKER="$REPO_ROOT/.test-passed-manual"
 STATUS_FILE="$REPO_ROOT/.test-status"
@@ -30,7 +31,7 @@ wait_for_marker() {
 }
 
 echo ""
-update_status "📋 STARTED: Running tests"
+update_status "📋 STARTED: Running tests [$BRANCH_NAME]"
 echo ""
 
 cd "$REPO_ROOT"

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -238,6 +238,7 @@ const WHISPER_SERVER_URL = 'http://localhost:5050';
 let currentSessionFile = null;
 let currentSessionNumber = 0;
 let activeSocket = null;
+let lastSentAssistantMessage = null;
 
 let lastDiffSent = null;
 let lastDiffHash = null;

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1319,16 +1319,13 @@ function handleLogMessage(socket, logData) {
         let commitHash = '';
 
         try {
-            const headPath = path.join(repoRoot, '.git', 'HEAD');
-            const headContent = fs.readFileSync(headPath, 'utf8').trim();
-            if (headContent.startsWith('ref: ')) {
-                const refPath = path.join(repoRoot, '.git', headContent.slice(5));
-                commitHash = fs.readFileSync(refPath, 'utf8').trim();
-            } else {
-                commitHash = headContent;
-            }
+            commitHash = require('child_process').execSync('git rev-parse HEAD', { 
+                encoding: 'utf8', 
+                stdio: ['pipe', 'pipe', 'pipe'],
+                cwd: repoRoot 
+            }).trim();
         } catch (gitErr) {
-            log(`Failed to read git HEAD: ${gitErr.message}`, 'handleLogMessage');
+            log(`Failed to get git HEAD: ${gitErr.message}`, 'handleLogMessage');
             return;
         }
 

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -123,6 +123,7 @@ const crypto = require('crypto');
 
 const IS_TEST = process.env.IS_TEST === 'true';
 const MANUAL_TESTING = process.env.MANUAL_TESTING === 'true';
+const useRealAudio = !IS_TEST || MANUAL_TESTING;
 const SERVER_PORT = parseInt(process.env.SERVER_PORT, 10) || 8082;
 let testFailed = false;
 
@@ -525,7 +526,7 @@ function deduplicateTranscription(newText, messageState, timestamp) {
 }
 
 async function transcribeAudio(audioPath) {
-    if (IS_TEST && !MANUAL_TESTING) {
+    if (!useRealAudio) {
         log(`Automated testing: Skipping Whisper, returning mock "hello"`, 'transcribeAudio');
         return { text: 'hello', segments: [] };
     }


### PR DESCRIPTION
## Summary
- PreToolUse hook blocks heavy tools (Edit, Write, Bash, WebFetch, WebSearch) in main repo
- Task tool only allowed with `run_in_background: true`
- Main agent = pure coordinator, all work via background agents in worktrees

## Bug fixes
- Declare `lastSentAssistantMessage` variable (was undefined)
- Use `git rev-parse HEAD` for worktree compatibility
- Simplify `useRealAudio = !IS_TEST || MANUAL_TESTING` flag
- Auto-create `private/logs` directory for worktrees
- Show branch name in test output

## Test plan
- [x] Automated tests pass
- [x] Manual tests pass  
- [x] Hook blocks Edit/Write/Bash in main repo
- [x] Task with run_in_background: true works

🤖 Generated with [Claude Code](https://claude.com/claude-code)