### PR TITLE
Add worktree enforcement hook

### DIFF
--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Hook: PreToolUse - blocks Edit/Write unless in a worktree
+# Main repo has .git as directory, worktree has .git as file
+# Exit code 2 = block, message to stderr
+
+# Check if .git is a directory (main repo) or file (worktree)
+if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  # Main repo - block edits with exit code 2
+  echo "BLOCKED: Cannot edit in main repo. Create worktree first: git worktree add ../worktrees/feature -b feature" >&2
+  exit 2
+fi
+
+# Worktree - allow
+exit 0


### PR DESCRIPTION
## Summary
- Adds PreToolUse hook that blocks Edit/Write in main repo
- Forces all edits to happen in worktrees
- Protects production from accidental changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)