### PR TITLE
Add worktree enforcement and coordinator pattern

### DIFF
--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Hook: PreToolUse - blocks Edit/Write unless in a worktree
+# Main repo has .git as directory, worktree has .git as file
+# Exit code 2 = block, message to stderr
+
+# Check if .git is a directory (main repo) or file (worktree)
+if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  # Main repo - block edits with exit code 2
+  echo "BLOCKED: Cannot edit in main repo. Create worktree first: git worktree add ../worktrees/feature -b feature" >&2
+  exit 2
+fi
+
+# Worktree - allow
+exit 0

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-# Hook: PreToolUse - blocks Edit/Write unless in a worktree
-# Main repo has .git as directory, worktree has .git as file
+# Hook: PreToolUse - blocks heavy tools in main repo
+# Main agent = coordinator only. Work happens in worktrees via background agents.
 # Exit code 2 = block, message to stderr
 
-# Check if .git is a directory (main repo) or file (worktree)
 if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
-  # Main repo - block edits with exit code 2
-  echo "BLOCKED: Cannot edit in main repo. Create worktree first: git worktree add ../worktrees/feature -b feature" >&2
+  echo "BLOCKED: Main agent is coordinator only. Use Task tool to spawn background agent in worktree." >&2
   exit 2
 fi
 

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -11,6 +11,14 @@ fi
 
 # Read tool input from stdin
 INPUT=$(cat)
+
+# Sub-agents (transcript filename starts with "agent-") are allowed everything
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+TRANSCRIPT_FILENAME=$(basename "$TRANSCRIPT_PATH" 2>/dev/null)
+if [[ "$TRANSCRIPT_FILENAME" == agent-* ]]; then
+  exit 0
+fi
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 
 # Task tool: only allow if run_in_background is true

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 
-# Hook: PreToolUse - enforces coordinator pattern in main repo
-# Main agent can only: Read, Glob, Grep, Task (background only)
-# Exit code 2 = block, message to stderr
-
-# Only enforce in main repo (not worktrees)
 if [ ! -d "$CLAUDE_PROJECT_DIR/.git" ]; then
   exit 0
 fi
 
-# Read tool input from stdin
 INPUT=$(cat)
 
-# Sub-agents (transcript filename starts with "agent-") are allowed everything
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 TRANSCRIPT_FILENAME=$(basename "$TRANSCRIPT_PATH" 2>/dev/null)
 if [[ "$TRANSCRIPT_FILENAME" == agent-* ]]; then
@@ -21,7 +14,6 @@ fi
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 
-# Task tool: only allow if run_in_background is true
 if [ "$TOOL_NAME" = "Task" ]; then
   RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
   if [ "$RUN_IN_BG" != "true" ]; then
@@ -31,6 +23,5 @@ if [ "$TOOL_NAME" = "Task" ]; then
   exit 0
 fi
 
-# All other matched tools (Edit, Write, Bash, WebFetch, WebSearch) are blocked
 echo "BLOCKED: Main agent is coordinator only. Use Task tool with run_in_background: true." >&2
 exit 2

--- a/.claude/hooks/enforce-worktree.sh
+++ b/.claude/hooks/enforce-worktree.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
 
-# Hook: PreToolUse - blocks heavy tools in main repo
-# Main agent = coordinator only. Work happens in worktrees via background agents.
+# Hook: PreToolUse - enforces coordinator pattern in main repo
+# Main agent can only: Read, Glob, Grep, Task (background only)
 # Exit code 2 = block, message to stderr
 
-if [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
-  echo "BLOCKED: Main agent is coordinator only. Use Task tool to spawn background agent in worktree." >&2
-  exit 2
+# Only enforce in main repo (not worktrees)
+if [ ! -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  exit 0
 fi
 
-# Worktree - allow
-exit 0
+# Read tool input from stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Task tool: only allow if run_in_background is true
+if [ "$TOOL_NAME" = "Task" ]; then
+  RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
+  if [ "$RUN_IN_BG" != "true" ]; then
+    echo "BLOCKED: Task must use run_in_background: true. Main agent is coordinator only." >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+# All other matched tools (Edit, Write, Bash, WebFetch, WebSearch) are blocked
+echo "BLOCKED: Main agent is coordinator only. Use Task tool with run_in_background: true." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "enableAllProjectMcpServers": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|Bash|WebFetch|WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/notify-claude-stopped.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|Bash|WebFetch|WebSearch",
+        "matcher": "Edit|Write|Bash|WebFetch|WebSearch|Task",
         "hooks": [
           {
             "type": "command",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "realtime-claude",
+  "name": "add-worktree-hook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -22,6 +22,9 @@ else
     BUILD_DIR='/tmp/build-test-auto'
 fi
 
+# Ensure required directories exist (not in git, needed at runtime)
+mkdir -p private/logs
+
 # Get iPhone ID early for terminating old app
 export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 IPHONE_ID=$(xcodebuild -scheme RealtimeClaude -showdestinations 2>/dev/null | grep "name:iPhone" | grep -o 'id:[^,]*' | head -1 | cut -d: -f2)

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -2,6 +2,7 @@
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 COMMIT_HASH=$(git rev-parse HEAD)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 AUTOMATED_MARKER="$REPO_ROOT/.test-passed-automated"
 MANUAL_MARKER="$REPO_ROOT/.test-passed-manual"
 STATUS_FILE="$REPO_ROOT/.test-status"
@@ -30,7 +31,7 @@ wait_for_marker() {
 }
 
 echo ""
-update_status "📋 STARTED: Running tests"
+update_status "📋 STARTED: Running tests [$BRANCH_NAME]"
 echo ""
 
 cd "$REPO_ROOT"

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -177,7 +177,7 @@ function error(message, functionName = 'unknown') {
         const marker = MANUAL_TESTING
             ? path.join(repoRoot, '.test-passed-manual')
             : path.join(repoRoot, '.test-passed-automated');
-        fs.writeFileSync(marker, 'ERROR');
+        fs.writeFileSync(marker, `ERROR|mac-server.js|${functionName}|${message}`);
         console.error('🚨 ERROR in test mode: Wrote ERROR to marker. Tests failed.');
     }
 }
@@ -1352,7 +1352,7 @@ function handleErrorMessage(socket, logData) {
         const marker = MANUAL_TESTING
             ? path.join(repoRoot, '.test-passed-manual')
             : path.join(repoRoot, '.test-passed-automated');
-        fs.writeFileSync(marker, 'ERROR');
+        fs.writeFileSync(marker, `ERROR|${logData.fileName}|${logData.functionName}|${logData.message}`);
         console.error('🚨 iOS ERROR in test mode: Wrote ERROR to marker. Tests failed.');
     }
 

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -238,6 +238,7 @@ const WHISPER_SERVER_URL = 'http://localhost:5050';
 let currentSessionFile = null;
 let currentSessionNumber = 0;
 let activeSocket = null;
+let lastSentAssistantMessage = null;
 
 let lastDiffSent = null;
 let lastDiffHash = null;

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1338,8 +1338,19 @@ function handleLogMessage(socket, logData) {
             log(`[DEBUG] HEAD content = ${headContent}`, 'handleLogMessage');
             
             if (headContent.startsWith('ref: ')) {
-                const refPath = path.join(gitDir, headContent.slice(5));
-                log(`[DEBUG] Reading ref from ${refPath}`, 'handleLogMessage');
+                let refPath = path.join(gitDir, headContent.slice(5));
+                log(`[DEBUG] Trying ref at ${refPath}`, 'handleLogMessage');
+                
+                if (!fs.existsSync(refPath)) {
+                    const commondirPath = path.join(gitDir, 'commondir');
+                    if (fs.existsSync(commondirPath)) {
+                        const commondir = fs.readFileSync(commondirPath, 'utf8').trim();
+                        const resolvedCommondir = path.resolve(gitDir, commondir);
+                        refPath = path.join(resolvedCommondir, headContent.slice(5));
+                        log(`[DEBUG] Ref not found, trying commondir: ${refPath}`, 'handleLogMessage');
+                    }
+                }
+                
                 commitHash = fs.readFileSync(refPath, 'utf8').trim();
             } else {
                 commitHash = headContent;

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1319,16 +1319,13 @@ function handleLogMessage(socket, logData) {
         let commitHash = '';
 
         try {
-            const headPath = path.join(repoRoot, '.git', 'HEAD');
-            const headContent = fs.readFileSync(headPath, 'utf8').trim();
-            if (headContent.startsWith('ref: ')) {
-                const refPath = path.join(repoRoot, '.git', headContent.slice(5));
-                commitHash = fs.readFileSync(refPath, 'utf8').trim();
-            } else {
-                commitHash = headContent;
-            }
+            commitHash = require('child_process').execSync('git rev-parse HEAD', { 
+                encoding: 'utf8', 
+                stdio: ['pipe', 'pipe', 'pipe'],
+                cwd: repoRoot 
+            }).trim();
         } catch (gitErr) {
-            log(`Failed to read git HEAD: ${gitErr.message}`, 'handleLogMessage');
+            log(`Failed to get git HEAD: ${gitErr.message}`, 'handleLogMessage');
             return;
         }
 

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -123,6 +123,7 @@ const crypto = require('crypto');
 
 const IS_TEST = process.env.IS_TEST === 'true';
 const MANUAL_TESTING = process.env.MANUAL_TESTING === 'true';
+const useRealAudio = !IS_TEST || MANUAL_TESTING;
 const SERVER_PORT = parseInt(process.env.SERVER_PORT, 10) || 8082;
 let testFailed = false;
 
@@ -525,7 +526,7 @@ function deduplicateTranscription(newText, messageState, timestamp) {
 }
 
 async function transcribeAudio(audioPath) {
-    if (IS_TEST && !MANUAL_TESTING) {
+    if (!useRealAudio) {
         log(`Automated testing: Skipping Whisper, returning mock "hello"`, 'transcribeAudio');
         return { text: 'hello', segments: [] };
     }

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1316,23 +1316,31 @@ function handleLogMessage(socket, logData) {
 
     if (IS_TEST && !testFailed && logData.message && logData.message.includes('Story complete')) {
         const repoRoot = path.dirname(__dirname);
-        log(`[DEBUG] repoRoot from __dirname = ${repoRoot}`, 'handleLogMessage');
+        log(`[DEBUG] repoRoot = ${repoRoot}`, 'handleLogMessage');
         
         let commitHash = '';
         try {
-            const gitHeadPath = path.join(repoRoot, '.git', 'HEAD');
-            let headContent = fs.readFileSync(gitHeadPath, 'utf8').trim();
+            const gitPath = path.join(repoRoot, '.git');
+            let gitDir;
+            
+            const gitStat = fs.statSync(gitPath);
+            if (gitStat.isFile()) {
+                const gitFileContent = fs.readFileSync(gitPath, 'utf8').trim();
+                gitDir = gitFileContent.replace('gitdir: ', '');
+                log(`[DEBUG] Worktree detected, gitDir = ${gitDir}`, 'handleLogMessage');
+            } else {
+                gitDir = gitPath;
+                log(`[DEBUG] Main repo detected, gitDir = ${gitDir}`, 'handleLogMessage');
+            }
+            
+            const headPath = path.join(gitDir, 'HEAD');
+            let headContent = fs.readFileSync(headPath, 'utf8').trim();
+            log(`[DEBUG] HEAD content = ${headContent}`, 'handleLogMessage');
             
             if (headContent.startsWith('ref: ')) {
-                const refPath = path.join(repoRoot, '.git', headContent.slice(5));
-                if (fs.existsSync(refPath)) {
-                    commitHash = fs.readFileSync(refPath, 'utf8').trim();
-                } else {
-                    const gitDir = fs.readFileSync(path.join(repoRoot, '.git'), 'utf8').trim();
-                    const actualGitDir = gitDir.replace('gitdir: ', '');
-                    const actualRefPath = path.join(actualGitDir, headContent.slice(5));
-                    commitHash = fs.readFileSync(actualRefPath, 'utf8').trim();
-                }
+                const refPath = path.join(gitDir, headContent.slice(5));
+                log(`[DEBUG] Reading ref from ${refPath}`, 'handleLogMessage');
+                commitHash = fs.readFileSync(refPath, 'utf8').trim();
             } else {
                 commitHash = headContent;
             }

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1315,7 +1315,10 @@ function handleLogMessage(socket, logData) {
     sendAcknowledgment(socket, logData.id);
 
     if (IS_TEST && !testFailed && logData.message && logData.message.includes('Story complete')) {
+        log(`[DEBUG] process.cwd() = ${process.cwd()}`, 'handleLogMessage');
+        log(`[DEBUG] __dirname = ${__dirname}`, 'handleLogMessage');
         const repoRoot = execSync('git rev-parse --show-toplevel', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']}).trim();
+        log(`[DEBUG] repoRoot from git = ${repoRoot}`, 'handleLogMessage');
         let commitHash = '';
 
         try {
@@ -1324,10 +1327,12 @@ function handleLogMessage(socket, logData) {
                 stdio: ['pipe', 'pipe', 'pipe'],
                 cwd: repoRoot 
             }).trim();
+            log(`[DEBUG] commitHash = ${commitHash}`, 'handleLogMessage');
         } catch (gitErr) {
             log(`Failed to get git HEAD: ${gitErr.message}`, 'handleLogMessage');
             return;
         }
+        log(`[DEBUG] Writing marker to ${repoRoot}`, 'handleLogMessage');
 
         if (MANUAL_TESTING) {
             const manualMarker = path.join(repoRoot, '.test-passed-manual');

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -1315,18 +1315,27 @@ function handleLogMessage(socket, logData) {
     sendAcknowledgment(socket, logData.id);
 
     if (IS_TEST && !testFailed && logData.message && logData.message.includes('Story complete')) {
-        log(`[DEBUG] process.cwd() = ${process.cwd()}`, 'handleLogMessage');
-        log(`[DEBUG] __dirname = ${__dirname}`, 'handleLogMessage');
-        const repoRoot = execSync('git rev-parse --show-toplevel', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']}).trim();
-        log(`[DEBUG] repoRoot from git = ${repoRoot}`, 'handleLogMessage');
+        const repoRoot = path.dirname(__dirname);
+        log(`[DEBUG] repoRoot from __dirname = ${repoRoot}`, 'handleLogMessage');
+        
         let commitHash = '';
-
         try {
-            commitHash = require('child_process').execSync('git rev-parse HEAD', { 
-                encoding: 'utf8', 
-                stdio: ['pipe', 'pipe', 'pipe'],
-                cwd: repoRoot 
-            }).trim();
+            const gitHeadPath = path.join(repoRoot, '.git', 'HEAD');
+            let headContent = fs.readFileSync(gitHeadPath, 'utf8').trim();
+            
+            if (headContent.startsWith('ref: ')) {
+                const refPath = path.join(repoRoot, '.git', headContent.slice(5));
+                if (fs.existsSync(refPath)) {
+                    commitHash = fs.readFileSync(refPath, 'utf8').trim();
+                } else {
+                    const gitDir = fs.readFileSync(path.join(repoRoot, '.git'), 'utf8').trim();
+                    const actualGitDir = gitDir.replace('gitdir: ', '');
+                    const actualRefPath = path.join(actualGitDir, headContent.slice(5));
+                    commitHash = fs.readFileSync(actualRefPath, 'utf8').trim();
+                }
+            } else {
+                commitHash = headContent;
+            }
             log(`[DEBUG] commitHash = ${commitHash}`, 'handleLogMessage');
         } catch (gitErr) {
             log(`Failed to get git HEAD: ${gitErr.message}`, 'handleLogMessage');

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -173,7 +173,7 @@ function error(message, functionName = 'unknown') {
     }
     if (IS_TEST && !testFailed) {
         testFailed = true;
-        const repoRoot = path.resolve(__dirname, '..');
+        const repoRoot = execSync('git rev-parse --show-toplevel', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']}).trim();
         const marker = MANUAL_TESTING
             ? path.join(repoRoot, '.test-passed-manual')
             : path.join(repoRoot, '.test-passed-automated');
@@ -1315,7 +1315,7 @@ function handleLogMessage(socket, logData) {
     sendAcknowledgment(socket, logData.id);
 
     if (IS_TEST && !testFailed && logData.message && logData.message.includes('Story complete')) {
-        const repoRoot = path.resolve(__dirname, '..');
+        const repoRoot = execSync('git rev-parse --show-toplevel', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']}).trim();
         let commitHash = '';
 
         try {
@@ -1348,7 +1348,7 @@ function handleErrorMessage(socket, logData) {
 
     if (IS_TEST && !testFailed) {
         testFailed = true;
-        const repoRoot = path.resolve(__dirname, '..');
+        const repoRoot = execSync('git rev-parse --show-toplevel', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']}).trim();
         const marker = MANUAL_TESTING
             ? path.join(repoRoot, '.test-passed-manual')
             : path.join(repoRoot, '.test-passed-automated');


### PR DESCRIPTION
## Summary
- Complete worktree enforcement hook (blocks Edit/Write in main repo)
- Coordinator pattern enforcement (main agent = coordinator only)
- Fixed EBADF error by using filesystem reads instead of execSync
- Fixed worktree git ref lookup via commondir

## Changes
- `.claude/hooks/enforce-worktree.sh` - Full enforcement hook
- `.claude/settings.json` - Hook configuration
- `scripts/mac-server.js` - Fixed git hash lookup for worktrees
- `scripts/deploy-test.sh` - Test improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)