### PR TITLE
Enforce dangerouslyDisableSandbox for background Bash commands

### DIFF
--- a/.claude/hooks/limit-main-agent.sh
+++ b/.claude/hooks/limit-main-agent.sh
@@ -44,21 +44,30 @@ if [ "$TOOL_NAME" = "Task" ]; then
 fi
 
 # =============================================================================
-# RULE 2: Bash must have run_in_background: true
+# RULE 2: Bash must have run_in_background: true AND dangerouslyDisableSandbox: true
 # =============================================================================
 if [ "$TOOL_NAME" = "Bash" ]; then
     RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
-    if [ "$RUN_IN_BG" = "true" ]; then
-        echo "RESULT: ALLOWED (Bash with run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        exit 0
-    else
+    DISABLE_SANDBOX=$(echo "$INPUT" | jq -r '.tool_input.dangerouslyDisableSandbox // false')
+
+    if [ "$RUN_IN_BG" != "true" ]; then
         echo "RESULT: BLOCKED (Bash without run_in_background)" >> "$LOG_FILE"
         echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
         echo "" >&2
         echo "BLOCKED: Bash requires run_in_background: true" >&2
         echo "Run commands in background to avoid blocking." >&2
         exit 2
+    elif [ "$DISABLE_SANDBOX" != "true" ]; then
+        echo "RESULT: BLOCKED (Bash without dangerouslyDisableSandbox)" >> "$LOG_FILE"
+        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        echo "" >&2
+        echo "BLOCKED: Bash requires dangerouslyDisableSandbox: true" >&2
+        echo "Sandbox blocks output file writes. Disable it for background commands." >&2
+        exit 2
+    else
+        echo "RESULT: ALLOWED (Bash with run_in_background + dangerouslyDisableSandbox)" >> "$LOG_FILE"
+        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        exit 0
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Sandbox blocks output file writes to `/private/tmp/claude/`, causing background bash to lose output silently
- Hook now requires BOTH `run_in_background: true` AND `dangerouslyDisableSandbox: true` for Bash
- Clear error messages when either flag is missing

## Test plan
- [ ] Test Bash without flags → blocked with "requires run_in_background" message
- [ ] Test Bash with only `run_in_background: true` → blocked with "requires dangerouslyDisableSandbox" message  
- [ ] Test Bash with both flags → allowed, output captured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)