### PR TITLE
TDD commit enforcement hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,3 +55,43 @@ With this: 200k context ÷ 500 per task = 400 tasks, immortal coordinator
 
 ### Pattern
 User speaks → Spawn agent → Keep talking → Get summary → Repeat forever
+
+## TDD COMMIT ENFORCEMENT
+
+**Every commit must have prefix: test: | impl: | refactor:**
+
+commit-msg hook validates via headless Claude agent.
+
+### test: - Specification
+
+PASS if diff adds:
+- pre(condition, message) - precondition guards
+- post(condition, message) - postcondition guards
+- inv(condition, message) - invariant guards
+- STORY test case entries
+- TEST_*_MARKER definitions
+- Test functions that emit markers
+
+FAIL if:
+- None of above added
+- ANY log() that isn't a test marker
+- Business logic
+
+### impl: - Implementation
+
+PASS if diff adds:
+- log() calls (the story/narrative)
+- Logic that makes contracts pass
+
+FAIL if:
+- No log() calls added
+- Only contracts (that's test:)
+
+### refactor: - Cleanup
+
+PASS if:
+- ZERO comments in added lines
+- Code is clean and readable
+
+FAIL if:
+- Any comment syntax in added lines

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -22,7 +22,7 @@ FAIL if:
 - ANY log() that isn't a test marker
 - Business logic
 
-You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+You MUST return exactly this JSON format: {\"pass\": true, \"reason\": \"explanation\"} or {\"pass\": false, \"reason\": \"what is missing\"}"
 
 elif [[ "$COMMIT_MSG" == impl:* ]]; then
     TYPE="impl"
@@ -38,7 +38,7 @@ FAIL if:
 - No narrative output added
 - Only contracts (that's test:)
 
-You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+You MUST return exactly this JSON format: {\"pass\": true, \"reason\": \"explanation\"} or {\"pass\": false, \"reason\": \"what is missing\"}"
 
 elif [[ "$COMMIT_MSG" == refactor:* ]]; then
     TYPE="refactor"
@@ -51,7 +51,7 @@ PASS if:
 FAIL if:
 - Any comment syntax in added lines
 
-You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+You MUST return exactly this JSON format: {\"pass\": true, \"reason\": \"explanation\"} or {\"pass\": false, \"reason\": \"what is missing\"}"
 
 else
     echo ""

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+COMMIT_MSG=$(cat "$1")
+GIT_DIFF=$(git diff --cached)
+
+if [[ "$COMMIT_MSG" == test:* ]]; then
+    TYPE="test"
+    PROMPT="SPECIFICATION COMMIT.
+
+PASS if diff adds:
+- pre(condition, message) - precondition guards
+- post(condition, message) - postcondition guards
+- inv(condition, message) - invariant guards
+- STORY test case entries
+- TEST_*_MARKER definitions
+- Test functions that emit markers
+
+Any combination valid. Defines WHAT must be true.
+
+FAIL if:
+- None of above added
+- ANY log() that isn't a test marker
+- Business logic
+
+You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+
+elif [[ "$COMMIT_MSG" == impl:* ]]; then
+    TYPE="impl"
+    PROMPT="IMPLEMENTATION COMMIT.
+
+PASS if diff adds:
+- Narrative output: log() in Swift, echo in bash, console.log in JS
+- Logic that makes contracts pass
+
+Story must be told via output statements.
+
+FAIL if:
+- No narrative output added
+- Only contracts (that's test:)
+
+You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+
+elif [[ "$COMMIT_MSG" == refactor:* ]]; then
+    TYPE="refactor"
+    PROMPT="REFACTOR COMMIT.
+
+PASS if:
+- ZERO comments in added lines (no //, /*, #)
+- Code is clean and readable
+
+FAIL if:
+- Any comment syntax in added lines
+
+You MUST return exactly this JSON format: {"pass": true, "reason": "explanation"} or {"pass": false, "reason": "what is missing"}"
+
+else
+    echo ""
+    echo "❌ TDD FAIL: Invalid commit prefix"
+    echo "   Required: test: | impl: | refactor:"
+    echo ""
+    echo "   test:     Add pre(), post(), inv() contracts (specification)"
+    echo "   impl:     Add log() and logic (implementation)"
+    echo "   refactor: Clean up, no comments"
+    echo ""
+    exit 1
+fi
+
+echo ""
+echo "🔍 TDD Enforcer checking $TYPE commit..."
+
+RESULT=$(claude -p --output-format json "$PROMPT
+
+Diff:
+$GIT_DIFF" 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+    echo "⚠️  Claude check skipped (not available)"
+    exit 0
+fi
+
+# Extract the result field, strip markdown code blocks, then parse JSON
+INNER_JSON=$(echo "$RESULT" | jq -r '.result' 2>/dev/null | sed 's/^```json//; s/^```//; s/```$//' | tr -d '\n')
+PASS=$(echo "$INNER_JSON" | jq -r '.pass' 2>/dev/null)
+REASON=$(echo "$INNER_JSON" | jq -r '.reason' 2>/dev/null)
+
+if [ "$PASS" != "true" ]; then
+    echo "❌ $TYPE FAIL: $REASON"
+    exit 1
+fi
+
+echo "✅ $TYPE PASS: $REASON"


### PR DESCRIPTION
## Summary
- Adds commit-msg hook that validates commits follow TDD pattern
- Requires test:/impl:/refactor: prefix on all commits
- Uses headless Claude to validate diff content

## Commits
- impl: Add TDD commit enforcement hook
- refactor: Fix JSON quote escaping in hook prompts