### PR TITLE
Strict TDD: add plan: commit type and plans exception

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,9 +58,28 @@ User speaks → Spawn agent → Keep talking → Get summary → Repeat forever
 
 ## TDD COMMIT ENFORCEMENT
 
-**Every commit must have prefix: test: | impl: | refactor:**
+**Every commit must have prefix: plan: | test: | impl: | refactor:**
 
 commit-msg hook validates via headless Claude agent.
+
+### Universal Rules (Uncle Bob)
+
+1. **BRANCH = TOPIC** - changes must relate to branch name
+2. **ONE THING** - focused on single behavior
+3. **MESSAGE MATCH** - describes exactly what diff does
+
+### plan: - Design
+
+PASS if diff adds:
+- Design documents or architecture decisions
+- Plan files (.md planning docs)
+- TODO lists or task breakdowns
+- Interface definitions (what, not how)
+
+FAIL if:
+- Contains implementation code
+- Contains test code (contracts)
+- No planning content added
 
 ### test: - Specification
 

--- a/.claude/hooks/limit-main-agent.sh
+++ b/.claude/hooks/limit-main-agent.sh
@@ -75,6 +75,14 @@ fi
 # RULE 3: Edit/Write must be in worktree
 # =============================================================================
 if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
+    # Exception: Allow writes to .claude/plans/ for plan mode
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+    if [[ "$FILE_PATH" == *"/.claude/plans/"* ]]; then
+        echo "RESULT: ALLOWED ($TOOL_NAME to plans directory)" >> "$LOG_FILE"
+        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        exit 0
+    fi
+
     if [ "$IS_WORKTREE" = "true" ]; then
         echo "RESULT: ALLOWED ($TOOL_NAME in worktree)" >> "$LOG_FILE"
         echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -3,7 +3,26 @@
 COMMIT_MSG=$(cat "$1")
 GIT_DIFF=$(git diff --cached)
 
-if [[ "$COMMIT_MSG" == test:* ]]; then
+if [[ "$COMMIT_MSG" == plan:* ]]; then
+    TYPE="plan"
+    PROMPT="PLANNING COMMIT.
+
+PASS if diff adds:
+- Design documents or architecture decisions
+- Plan files (.md planning docs)
+- TODO lists or task breakdowns
+- Interface definitions (what, not how)
+
+Defines the approach before implementation.
+
+FAIL if:
+- Contains implementation code
+- Contains test code (contracts)
+- No planning content added
+
+You MUST return exactly this JSON format: {\"pass\": true, \"reason\": \"explanation\"} or {\"pass\": false, \"reason\": \"what is missing\"}"
+
+elif [[ "$COMMIT_MSG" == test:* ]]; then
     TYPE="test"
     PROMPT="SPECIFICATION COMMIT.
 
@@ -56,8 +75,9 @@ You MUST return exactly this JSON format: {\"pass\": true, \"reason\": \"explana
 else
     echo ""
     echo "❌ TDD FAIL: Invalid commit prefix"
-    echo "   Required: test: | impl: | refactor:"
+    echo "   Required: plan: | test: | impl: | refactor:"
     echo ""
+    echo "   plan:     Add design docs, architecture, plans"
     echo "   test:     Add pre(), post(), inv() contracts (specification)"
     echo "   impl:     Add log() and logic (implementation)"
     echo "   refactor: Clean up, no comments"


### PR DESCRIPTION
## Summary
- Adds plan: commit type for design/architecture commits
- Adds exception to allow writes to .claude/plans/ (for plan mode)
- Updates CLAUDE.md with Uncle Bob rules

## Flow
plan: → test: → impl: → refactor: