### PR TITLE
feat: block --no-verify in Claude hooks

### DIFF
--- a/.claude/hooks/limit-main-agent.sh
+++ b/.claude/hooks/limit-main-agent.sh
@@ -13,36 +13,39 @@ fi
 
 BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "unknown")
 
-{
-    echo "════════════════════════════════════════════════════════════════"
-    echo "TIME: $(date)"
-    echo "TOOL: $TOOL_NAME"
-    echo "CWD: $CWD"
-    echo "BRANCH: $BRANCH"
-    echo "IS_WORKTREE: $IS_WORKTREE"
-} >> "$LOG_FILE"
+log() {
+    echo "$1" >> "$LOG_FILE"
+}
+
+log "════════════════════════════════════════════════════════════════"
+log "TIME: $(date)"
+log "TOOL: $TOOL_NAME"
+log "CWD: $CWD"
+log "BRANCH: $BRANCH"
+log "IS_WORKTREE: $IS_WORKTREE"
 
 pre() {
     local condition="$1"
     local message="$2"
     if [ "$condition" != "true" ]; then
-        echo "RESULT: BLOCKED ($message)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: BLOCKED ($message)"
+        log "════════════════════════════════════════════════════════════════"
         echo "" >&2
         echo "PRE: $message" >&2
         exit 2
     fi
+    log "CHECK: pre($message) passed"
 }
 
 if [ "$TOOL_NAME" = "Task" ]; then
     RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
     if [ "$RUN_IN_BG" = "true" ]; then
-        echo "RESULT: ALLOWED (Task with run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: ALLOWED (Task with run_in_background)"
+        log "════════════════════════════════════════════════════════════════"
         exit 0
     else
-        echo "RESULT: BLOCKED (Task without run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: BLOCKED (Task without run_in_background)"
+        log "════════════════════════════════════════════════════════════════"
         echo "" >&2
         echo "BLOCKED: Task requires run_in_background: true" >&2
         echo "You are the coordinator. Spawn background agents, don't block." >&2
@@ -55,26 +58,27 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     DISABLE_SANDBOX=$(echo "$INPUT" | jq -r '.tool_input.dangerouslyDisableSandbox // false')
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
+    log "Checking Bash command for --no-verify..."
     NO_VERIFY_CHECK=$(echo "$COMMAND" | grep -qE '\-\-no-verify' && echo "false" || echo "true")
     pre "$NO_VERIFY_CHECK" "git commands must not contain --no-verify"
 
     if [ "$RUN_IN_BG" != "true" ]; then
-        echo "RESULT: BLOCKED (Bash without run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: BLOCKED (Bash without run_in_background)"
+        log "════════════════════════════════════════════════════════════════"
         echo "" >&2
         echo "BLOCKED: Bash requires run_in_background: true" >&2
         echo "Run commands in background to avoid blocking." >&2
         exit 2
     elif [ "$DISABLE_SANDBOX" != "true" ]; then
-        echo "RESULT: BLOCKED (Bash without dangerouslyDisableSandbox)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: BLOCKED (Bash without dangerouslyDisableSandbox)"
+        log "════════════════════════════════════════════════════════════════"
         echo "" >&2
         echo "BLOCKED: Bash requires dangerouslyDisableSandbox: true" >&2
         echo "Sandbox blocks output file writes. Disable it for background commands." >&2
         exit 2
     else
-        echo "RESULT: ALLOWED (Bash with run_in_background + dangerouslyDisableSandbox)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: ALLOWED (Bash with run_in_background + dangerouslyDisableSandbox)"
+        log "════════════════════════════════════════════════════════════════"
         exit 0
     fi
 fi
@@ -82,18 +86,18 @@ fi
 if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
     if [[ "$FILE_PATH" == *"/.claude/plans/"* ]]; then
-        echo "RESULT: ALLOWED ($TOOL_NAME to plans directory)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: ALLOWED ($TOOL_NAME to plans directory)"
+        log "════════════════════════════════════════════════════════════════"
         exit 0
     fi
 
     if [ "$IS_WORKTREE" = "true" ]; then
-        echo "RESULT: ALLOWED ($TOOL_NAME in worktree)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: ALLOWED ($TOOL_NAME in worktree)"
+        log "════════════════════════════════════════════════════════════════"
         exit 0
     else
-        echo "RESULT: BLOCKED ($TOOL_NAME not in worktree)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        log "RESULT: BLOCKED ($TOOL_NAME not in worktree)"
+        log "════════════════════════════════════════════════════════════════"
         echo "" >&2
         echo "BLOCKED: $TOOL_NAME not allowed outside worktree." >&2
         echo "CWD: $CWD (branch: $BRANCH)" >&2
@@ -102,6 +106,6 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     fi
 fi
 
-echo "RESULT: ALLOWED ($TOOL_NAME)" >> "$LOG_FILE"
-echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+log "RESULT: ALLOWED ($TOOL_NAME)"
+log "════════════════════════════════════════════════════════════════"
 exit 0

--- a/.claude/hooks/limit-main-agent.sh
+++ b/.claude/hooks/limit-main-agent.sh
@@ -6,7 +6,6 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 LOG_FILE="/tmp/hook-coordinator.log"
 
-# Check if in worktree
 IS_WORKTREE=false
 if [[ "$CWD" == *"/worktrees/"* ]]; then
     IS_WORKTREE=true
@@ -14,7 +13,6 @@ fi
 
 BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "unknown")
 
-# Log
 {
     echo "════════════════════════════════════════════════════════════════"
     echo "TIME: $(date)"
@@ -24,9 +22,18 @@ BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "unknown")
     echo "IS_WORKTREE: $IS_WORKTREE"
 } >> "$LOG_FILE"
 
-# =============================================================================
-# RULE 1: Task must have run_in_background: true
-# =============================================================================
+pre() {
+    local condition="$1"
+    local message="$2"
+    if [ "$condition" != "true" ]; then
+        echo "RESULT: BLOCKED ($message)" >> "$LOG_FILE"
+        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+        echo "" >&2
+        echo "PRE: $message" >&2
+        exit 2
+    fi
+}
+
 if [ "$TOOL_NAME" = "Task" ]; then
     RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
     if [ "$RUN_IN_BG" = "true" ]; then
@@ -43,12 +50,13 @@ if [ "$TOOL_NAME" = "Task" ]; then
     fi
 fi
 
-# =============================================================================
-# RULE 2: Bash must have run_in_background: true AND dangerouslyDisableSandbox: true
-# =============================================================================
 if [ "$TOOL_NAME" = "Bash" ]; then
     RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
     DISABLE_SANDBOX=$(echo "$INPUT" | jq -r '.tool_input.dangerouslyDisableSandbox // false')
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+    NO_VERIFY_CHECK=$(echo "$COMMAND" | grep -qE '\-\-no-verify' && echo "false" || echo "true")
+    pre "$NO_VERIFY_CHECK" "git commands must not contain --no-verify"
 
     if [ "$RUN_IN_BG" != "true" ]; then
         echo "RESULT: BLOCKED (Bash without run_in_background)" >> "$LOG_FILE"
@@ -71,11 +79,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     fi
 fi
 
-# =============================================================================
-# RULE 3: Edit/Write must be in worktree
-# =============================================================================
 if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
-    # Exception: Allow writes to .claude/plans/ for plan mode
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
     if [[ "$FILE_PATH" == *"/.claude/plans/"* ]]; then
         echo "RESULT: ALLOWED ($TOOL_NAME to plans directory)" >> "$LOG_FILE"
@@ -98,9 +102,6 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     fi
 fi
 
-# =============================================================================
-# RULE 4: Everything else allowed
-# =============================================================================
 echo "RESULT: ALLOWED ($TOOL_NAME)" >> "$LOG_FILE"
 echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
 exit 0

--- a/plans/block-no-verify.md
+++ b/plans/block-no-verify.md
@@ -1,0 +1,10 @@
+# Plan: Block --no-verify
+
+## Goal
+Prevent bypassing git hooks with --no-verify flag.
+
+## Implementation
+Add to .claude/hooks/ a hook that detects --no-verify usage and blocks it.
+
+## Files Changed
+- `.claude/hooks/block-no-verify.sh` (NEW)


### PR DESCRIPTION
## Summary
- Adds `pre()` function for contract-style precondition guards
- Blocks Bash commands containing `--no-verify` before execution
- Adds `log()` function for consistent narrative logging

## Commits
- `plan: block --no-verify`
- `test: add pre() guard for --no-verify blocking`
- `impl: add narrative logging for --no-verify check`

## Test plan
- [ ] Try running `git commit --no-verify` - should be blocked
- [ ] Try running `git push --no-verify` - should be blocked
- [ ] Normal git commands should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)