### PR TITLE
Add plan acceptance verification hook

### DIFF
--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -5,6 +5,18 @@ GIT_DIFF=$(git diff --cached)
 
 if [[ "$COMMIT_MSG" == plan:* ]]; then
     TYPE="plan"
+    
+    HOOK_DIR="$(dirname "$0")"
+    if [[ -f "$HOOK_DIR/verify-plan-accepted.sh" ]]; then
+        "$HOOK_DIR/verify-plan-accepted.sh" || {
+            echo ""
+            echo "BLOCKED: plan: commit requires ExitPlanMode acceptance"
+            echo "   Accept your plan in Claude Code UI first"
+            echo ""
+            exit 1
+        }
+    fi
+    
     PROMPT="PLANNING COMMIT.
 
 PASS if diff adds:

--- a/scripts/hooks/verify-plan-accepted.sh
+++ b/scripts/hooks/verify-plan-accepted.sh
@@ -30,22 +30,35 @@ inv_exit_code_matches_result() {
 TRANSCRIPT_DIR="$HOME/.claude/projects/-Users-felixlunzenfichter-Documents-realtime-claude"
 
 echo "TEST_PLAN_ACCEPTANCE_CHECK_START"
-echo "Checking for plan acceptance in Claude transcripts..."
+echo ""
+echo "=== Plan Acceptance Verification ==="
+echo ""
+echo "Verifying plan acceptance..."
+echo "Checking transcript directory: $TRANSCRIPT_DIR"
 
 pre_transcript_dir_exists "$TRANSCRIPT_DIR"
 
+echo "Transcript directory exists."
+echo ""
+echo "Searching for 'Implement the following plan' in transcripts..."
+
 if command -v rg &>/dev/null; then
+    echo "Using ripgrep for search..."
     MATCH=$(rg -l --max-count=1 --glob '*.jsonl' 'Implement the following plan' "$TRANSCRIPT_DIR" 2>/dev/null | head -1)
 else
+    echo "Using find/grep for search (ripgrep not available)..."
     MATCH=$(find "$TRANSCRIPT_DIR" -maxdepth 1 -name '*.jsonl' -exec grep -l 'Implement the following plan' {} + 2>/dev/null | head -1)
 fi
 
+echo ""
 if [[ -n "$MATCH" ]]; then
-    echo "Found plan acceptance in: $MATCH"
+    echo "Found acceptance evidence in: $MATCH"
+    echo "Plan was accepted via ExitPlanMode."
     RESULT="PASS"
     EXIT_CODE=0
 else
-    echo "No plan acceptance found - use ExitPlanMode to accept your plan"
+    echo "No acceptance evidence found in transcripts."
+    echo "To accept a plan, use ExitPlanMode with 'Implement the following plan'."
     RESULT="FAIL"
     EXIT_CODE=1
 fi
@@ -53,5 +66,7 @@ fi
 post_result_is_pass_or_fail "$RESULT"
 inv_exit_code_matches_result "$RESULT" "$EXIT_CODE"
 
+echo ""
+echo "=== Verification Complete ==="
 echo "TEST_PLAN_ACCEPTANCE_RESULT: $RESULT"
 exit $EXIT_CODE

--- a/scripts/hooks/verify-plan-accepted.sh
+++ b/scripts/hooks/verify-plan-accepted.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TRANSCRIPT_DIR="$HOME/.claude/projects/-Users-felixlunzenfichter-Documents-realtime-claude"
+
+echo "Checking for plan acceptance in Claude transcripts..."
+
+if [[ ! -d "$TRANSCRIPT_DIR" ]]; then
+    echo "FAIL: No transcript directory found"
+    exit 1
+fi
+
+if command -v rg &>/dev/null; then
+    RESULT=$(rg -l --max-count=1 --glob '*.jsonl' 'Implement the following plan' "$TRANSCRIPT_DIR" 2>/dev/null | head -1)
+else
+    RESULT=$(find "$TRANSCRIPT_DIR" -maxdepth 1 -name '*.jsonl' -exec grep -l 'Implement the following plan' {} + 2>/dev/null | head -1)
+fi
+
+if [[ -n "$RESULT" ]]; then
+    echo "Found plan acceptance in: $RESULT"
+    echo "PASS: Plan acceptance verified"
+    exit 0
+fi
+
+echo "FAIL: No plan acceptance found - use ExitPlanMode to accept your plan"
+exit 1

--- a/scripts/hooks/verify-plan-accepted.sh
+++ b/scripts/hooks/verify-plan-accepted.sh
@@ -1,25 +1,57 @@
 #!/bin/bash
 
+# =============================================================================
+# CONTRACTS
+# =============================================================================
+
+pre_transcript_dir_exists() {
+    [[ -d "$1" ]] || { echo "PRE: transcript directory must exist: $1"; exit 1; }
+}
+
+post_result_is_pass_or_fail() {
+    [[ "$1" == "PASS" || "$1" == "FAIL" ]] || { echo "POST: result must be PASS or FAIL, got: $1"; exit 1; }
+}
+
+inv_exit_code_matches_result() {
+    local result="$1"
+    local exit_code="$2"
+    if [[ "$result" == "PASS" && "$exit_code" != "0" ]]; then
+        echo "INV: PASS must exit 0, got $exit_code"; exit 1
+    fi
+    if [[ "$result" == "FAIL" && "$exit_code" != "1" ]]; then
+        echo "INV: FAIL must exit 1, got $exit_code"; exit 1
+    fi
+}
+
+# =============================================================================
+# IMPLEMENTATION
+# =============================================================================
+
 TRANSCRIPT_DIR="$HOME/.claude/projects/-Users-felixlunzenfichter-Documents-realtime-claude"
 
+echo "TEST_PLAN_ACCEPTANCE_CHECK_START"
 echo "Checking for plan acceptance in Claude transcripts..."
 
-if [[ ! -d "$TRANSCRIPT_DIR" ]]; then
-    echo "FAIL: No transcript directory found"
-    exit 1
-fi
+pre_transcript_dir_exists "$TRANSCRIPT_DIR"
 
 if command -v rg &>/dev/null; then
-    RESULT=$(rg -l --max-count=1 --glob '*.jsonl' 'Implement the following plan' "$TRANSCRIPT_DIR" 2>/dev/null | head -1)
+    MATCH=$(rg -l --max-count=1 --glob '*.jsonl' 'Implement the following plan' "$TRANSCRIPT_DIR" 2>/dev/null | head -1)
 else
-    RESULT=$(find "$TRANSCRIPT_DIR" -maxdepth 1 -name '*.jsonl' -exec grep -l 'Implement the following plan' {} + 2>/dev/null | head -1)
+    MATCH=$(find "$TRANSCRIPT_DIR" -maxdepth 1 -name '*.jsonl' -exec grep -l 'Implement the following plan' {} + 2>/dev/null | head -1)
 fi
 
-if [[ -n "$RESULT" ]]; then
-    echo "Found plan acceptance in: $RESULT"
-    echo "PASS: Plan acceptance verified"
-    exit 0
+if [[ -n "$MATCH" ]]; then
+    echo "Found plan acceptance in: $MATCH"
+    RESULT="PASS"
+    EXIT_CODE=0
+else
+    echo "No plan acceptance found - use ExitPlanMode to accept your plan"
+    RESULT="FAIL"
+    EXIT_CODE=1
 fi
 
-echo "FAIL: No plan acceptance found - use ExitPlanMode to accept your plan"
-exit 1
+post_result_is_pass_or_fail "$RESULT"
+inv_exit_code_matches_result "$RESULT" "$EXIT_CODE"
+
+echo "TEST_PLAN_ACCEPTANCE_RESULT: $RESULT"
+exit $EXIT_CODE

--- a/scripts/hooks/verify-plan-accepted.sh
+++ b/scripts/hooks/verify-plan-accepted.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# =============================================================================
-# CONTRACTS
-# =============================================================================
-
 pre_transcript_dir_exists() {
     [[ -d "$1" ]] || { echo "PRE: transcript directory must exist: $1"; exit 1; }
 }
@@ -22,10 +18,6 @@ inv_exit_code_matches_result() {
         echo "INV: FAIL must exit 1, got $exit_code"; exit 1
     fi
 }
-
-# =============================================================================
-# IMPLEMENTATION
-# =============================================================================
 
 TRANSCRIPT_DIR="$HOME/.claude/projects/-Users-felixlunzenfichter-Documents-realtime-claude"
 


### PR DESCRIPTION
## Summary
- Blocks plan: commits unless ExitPlanMode acceptance found in Claude transcripts
- Searches for "Implement the following plan" in .jsonl transcript files
- Integrates with commit-msg hook

## TDD Commits
- plan: add plan acceptance verification hook
- test: add contracts for plan acceptance verification
- impl: add narrative output to plan acceptance verification
- refactor: clean up plan acceptance verification

## Test plan
- [x] Failing test: plan: commit blocked without acceptance
- [x] Passing test: plan: commit allowed with acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)