### PR TITLE
Simplify TDD gatekeeper - plan requires acceptance, others auto-push

### DIFF
--- a/.claude/hooks/plan-accepted.sh
+++ b/.claude/hooks/plan-accepted.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+if [ "$TOOL_NAME" = "ExitPlanMode" ]; then
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$REPO_ROOT" ]; then
+        COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null)
+        echo "$COMMIT_HASH" > "$REPO_ROOT/.plan-accepted"
+        echo "✅ Plan accepted. You can now push the plan: commit."
+    fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/plan-accepted.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -3,6 +3,18 @@
 COMMIT_MSG=$(cat "$1")
 GIT_DIFF=$(git diff --cached)
 
+UNPUSHED=$(git log --oneline @{upstream}..HEAD 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$UNPUSHED" -gt 0 ]; then
+    echo ""
+    echo "❌ Cannot commit: previous commit not pushed yet"
+    echo "   Unpushed commits: $UNPUSHED"
+    git log --oneline @{upstream}..HEAD 2>/dev/null
+    echo ""
+    echo "   Push first, then commit."
+    exit 1
+fi
+
 if [[ "$COMMIT_MSG" == plan:* ]]; then
     TYPE="plan"
     PROMPT="PLANNING COMMIT.

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -10,7 +10,6 @@ if [[ "$COMMIT_MSG" == plan:* ]]; then
     exit 0
 fi
 
-# test/impl/refactor - push immediately (tests disabled for now)
 echo ""
 echo "🚀 Pushing..."
 git push origin HEAD

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -3,72 +3,182 @@
 REPO_ROOT=$(git rev-parse --show-toplevel)
 COMMIT_HASH=$(git rev-parse HEAD)
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-AUTOMATED_MARKER="$REPO_ROOT/.test-passed-automated"
-MANUAL_MARKER="$REPO_ROOT/.test-passed-manual"
+COMMIT_MSG=$(git log -1 --format=%s)
 STATUS_FILE="$REPO_ROOT/.test-status"
+LOG_FILE="/tmp/mac-server-output.log"
+TIMEOUT_SECONDS=120
 
 update_status() {
     echo "$1 $COMMIT_HASH $(date '+%H:%M:%S')" >> "$STATUS_FILE"
     echo "$1"
 }
 
-wait_for_marker() {
-    local marker_file="$1"
-    local expected_hash="$2"
+watch_log_for_result() {
+    local start_time=$(date +%s)
+    local start_line=1
+
+    if [ -f "$LOG_FILE" ]; then
+        start_line=$(($(wc -l < "$LOG_FILE") + 1))
+    fi
 
     while true; do
-        if [ -f "$marker_file" ]; then
-            local marker_content=$(cat "$marker_file")
-            if [ "$marker_content" = "ERROR" ]; then
-                return 1
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+
+        if [ $elapsed -ge $TIMEOUT_SECONDS ]; then
+            echo "TIMEOUT"
+            return
+        fi
+
+        if [ -f "$LOG_FILE" ]; then
+            local new_content=$(tail -n +$start_line "$LOG_FILE" 2>/dev/null)
+
+            if echo "$new_content" | grep -q "Story complete"; then
+                echo "STORY_COMPLETE"
+                return
             fi
-            if [ "$marker_content" = "$expected_hash" ]; then
-                return 0
+
+            if echo "$new_content" | grep -q "error("; then
+                echo "ERROR"
+                return
             fi
         fi
-        fswatch -1 --event Created --event Updated "$REPO_ROOT" >/dev/null 2>&1
+
+        sleep 0.5
     done
 }
 
-echo ""
-update_status "📋 STARTED: Running tests [$BRANCH_NAME]"
-echo ""
-
 cd "$REPO_ROOT"
 
-rm -f "$AUTOMATED_MARKER" "$MANUAL_MARKER"
-
-update_status "🤖 DEPLOYING_AUTOMATED"
-./scripts/deploy-test.sh
-
-if [ $? -ne 0 ]; then
+if [[ "$COMMIT_MSG" == plan:* ]]; then
     echo ""
-    update_status "❌ FAILED: Automated deploy failed"
-    exit 1
+    update_status "📋 PLAN COMMIT: No tests needed"
+    echo "   Pushing plan commit..."
+    echo ""
+    git push origin HEAD
+    update_status "✅ COMPLETE: plan: commit pushed"
+    exit 0
+
+elif [[ "$COMMIT_MSG" == test:* ]]; then
+    echo ""
+    update_status "📋 TEST COMMIT: Running automated tests (expect FAIL)"
+    echo ""
+
+    update_status "🤖 DEPLOYING_AUTOMATED"
+    ./scripts/deploy-test.sh
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        update_status "❌ FAILED: Automated deploy failed"
+        exit 1
+    fi
+
+    echo ""
+    update_status "⏳ WATCHING LOG (expecting error)"
+    RESULT=$(watch_log_for_result)
+
+    if [ "$RESULT" = "ERROR" ]; then
+        update_status "✅ TEST COMMIT PASSED: Test correctly fails (TDD red phase)"
+        echo ""
+        update_status "🚀 PUSHING"
+        git push origin HEAD
+        update_status "✅ COMPLETE: test: commit pushed"
+    elif [ "$RESULT" = "STORY_COMPLETE" ]; then
+        update_status "❌ TEST COMMIT FAILED: Story completed but should have failed"
+        echo "   Your test: commit should add failing tests."
+        echo "   If tests pass, there's nothing new to implement."
+        exit 1
+    else
+        update_status "❌ TEST COMMIT FAILED: Timeout waiting for test result"
+        exit 1
+    fi
+
+elif [[ "$COMMIT_MSG" == impl:* ]]; then
+    echo ""
+    update_status "📋 IMPL COMMIT: Running automated tests (expect PASS)"
+    echo ""
+
+    update_status "🤖 DEPLOYING_AUTOMATED"
+    ./scripts/deploy-test.sh
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        update_status "❌ FAILED: Automated deploy failed"
+        exit 1
+    fi
+
+    echo ""
+    update_status "⏳ WATCHING LOG (expecting Story complete)"
+    RESULT=$(watch_log_for_result)
+
+    if [ "$RESULT" = "STORY_COMPLETE" ]; then
+        update_status "✅ IMPL COMMIT PASSED: Tests pass (TDD green phase)"
+        echo ""
+        update_status "🚀 PUSHING"
+        git push origin HEAD
+        update_status "✅ COMPLETE: impl: commit pushed"
+    elif [ "$RESULT" = "ERROR" ]; then
+        update_status "❌ IMPL COMMIT FAILED: Tests still failing"
+        echo "   Your impl: commit should make tests pass."
+        exit 1
+    else
+        update_status "❌ IMPL COMMIT FAILED: Timeout waiting for test result"
+        exit 1
+    fi
+
+elif [[ "$COMMIT_MSG" == refactor:* ]]; then
+    echo ""
+    update_status "📋 REFACTOR COMMIT: Running all tests (expect PASS)"
+    echo ""
+
+    update_status "🤖 DEPLOYING_AUTOMATED"
+    ./scripts/deploy-test.sh
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        update_status "❌ FAILED: Automated deploy failed"
+        exit 1
+    fi
+
+    echo ""
+    update_status "⏳ WATCHING LOG (automated - expecting Story complete)"
+    RESULT=$(watch_log_for_result)
+
+    if [ "$RESULT" = "ERROR" ]; then
+        update_status "❌ REFACTOR FAILED: Automated tests failed"
+        echo "   Refactoring should not break tests."
+        exit 1
+    elif [ "$RESULT" = "TIMEOUT" ]; then
+        update_status "❌ REFACTOR FAILED: Timeout waiting for automated test result"
+        exit 1
+    fi
+    update_status "✅ AUTOMATED_PASSED"
+
+    echo ""
+    update_status "👤 DEPLOYING_MANUAL"
+    ./scripts/deploy-test.sh --manual
+
+    echo ""
+    update_status "⏳ WATCHING LOG (manual - expecting Story complete)"
+    RESULT=$(watch_log_for_result)
+
+    if [ "$RESULT" = "ERROR" ]; then
+        update_status "❌ REFACTOR FAILED: Manual tests failed"
+        echo "   Refactoring should not break tests."
+        exit 1
+    elif [ "$RESULT" = "TIMEOUT" ]; then
+        update_status "❌ REFACTOR FAILED: Timeout waiting for manual test result"
+        exit 1
+    fi
+    update_status "✅ MANUAL_PASSED"
+
+    echo ""
+    update_status "🚀 PUSHING"
+    git push origin HEAD
+    update_status "✅ COMPLETE: refactor: commit pushed"
+
+else
+    echo ""
+    echo "⚠️  Unknown commit type. No tests run."
+    echo ""
 fi
-
-echo ""
-update_status "⏳ WAITING_AUTOMATED"
-if ! wait_for_marker "$AUTOMATED_MARKER" "$COMMIT_HASH"; then
-    update_status "❌ FAILED: Automated test error"
-    exit 1
-fi
-update_status "✅ AUTOMATED_PASSED"
-
-echo ""
-update_status "👤 DEPLOYING_MANUAL"
-./scripts/deploy-test.sh --manual
-
-echo ""
-update_status "⏳ WAITING_MANUAL"
-if ! wait_for_marker "$MANUAL_MARKER" "$COMMIT_HASH"; then
-    update_status "❌ FAILED: Manual test error"
-    exit 1
-fi
-update_status "✅ MANUAL_PASSED"
-
-echo ""
-update_status "🚀 PUSHING"
-git push origin HEAD
-
-update_status "✅ COMPLETE: All tests passed and pushed"

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -1,184 +1,23 @@
 #!/bin/bash
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-COMMIT_HASH=$(git rev-parse HEAD)
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 COMMIT_MSG=$(git log -1 --format=%s)
-STATUS_FILE="$REPO_ROOT/.test-status"
-LOG_FILE="/tmp/mac-server-output.log"
-TIMEOUT_SECONDS=120
-
-update_status() {
-    echo "$1 $COMMIT_HASH $(date '+%H:%M:%S')" >> "$STATUS_FILE"
-    echo "$1"
-}
-
-watch_log_for_result() {
-    local start_time=$(date +%s)
-    local start_line=1
-
-    if [ -f "$LOG_FILE" ]; then
-        start_line=$(($(wc -l < "$LOG_FILE") + 1))
-    fi
-
-    while true; do
-        local current_time=$(date +%s)
-        local elapsed=$((current_time - start_time))
-
-        if [ $elapsed -ge $TIMEOUT_SECONDS ]; then
-            echo "TIMEOUT"
-            return
-        fi
-
-        if [ -f "$LOG_FILE" ]; then
-            local new_content=$(tail -n +$start_line "$LOG_FILE" 2>/dev/null)
-
-            if echo "$new_content" | grep -q "Story complete"; then
-                echo "STORY_COMPLETE"
-                return
-            fi
-
-            if echo "$new_content" | grep -q "error("; then
-                echo "ERROR"
-                return
-            fi
-        fi
-
-        sleep 0.5
-    done
-}
-
-cd "$REPO_ROOT"
 
 if [[ "$COMMIT_MSG" == plan:* ]]; then
     echo ""
-    update_status "📋 PLAN COMMIT: No tests needed"
-    echo "   Pushing plan commit..."
+    echo "📋 Plan committed. Accept in Claude Code CLI to push."
+    echo "   (ExitPlanMode writes .plan-accepted)"
     echo ""
-    git push origin HEAD
-    update_status "✅ COMPLETE: plan: commit pushed"
     exit 0
+fi
 
-elif [[ "$COMMIT_MSG" == test:* ]]; then
-    echo ""
-    update_status "📋 TEST COMMIT: Running automated tests (expect FAIL)"
-    echo ""
+# test/impl/refactor - push immediately (tests disabled for now)
+echo ""
+echo "🚀 Pushing..."
+git push origin HEAD
 
-    update_status "🤖 DEPLOYING_AUTOMATED"
-    ./scripts/deploy-test.sh
-
-    if [ $? -ne 0 ]; then
-        echo ""
-        update_status "❌ FAILED: Automated deploy failed"
-        exit 1
-    fi
-
-    echo ""
-    update_status "⏳ WATCHING LOG (expecting error)"
-    RESULT=$(watch_log_for_result)
-
-    if [ "$RESULT" = "ERROR" ]; then
-        update_status "✅ TEST COMMIT PASSED: Test correctly fails (TDD red phase)"
-        echo ""
-        update_status "🚀 PUSHING"
-        git push origin HEAD
-        update_status "✅ COMPLETE: test: commit pushed"
-    elif [ "$RESULT" = "STORY_COMPLETE" ]; then
-        update_status "❌ TEST COMMIT FAILED: Story completed but should have failed"
-        echo "   Your test: commit should add failing tests."
-        echo "   If tests pass, there's nothing new to implement."
-        exit 1
-    else
-        update_status "❌ TEST COMMIT FAILED: Timeout waiting for test result"
-        exit 1
-    fi
-
-elif [[ "$COMMIT_MSG" == impl:* ]]; then
-    echo ""
-    update_status "📋 IMPL COMMIT: Running automated tests (expect PASS)"
-    echo ""
-
-    update_status "🤖 DEPLOYING_AUTOMATED"
-    ./scripts/deploy-test.sh
-
-    if [ $? -ne 0 ]; then
-        echo ""
-        update_status "❌ FAILED: Automated deploy failed"
-        exit 1
-    fi
-
-    echo ""
-    update_status "⏳ WATCHING LOG (expecting Story complete)"
-    RESULT=$(watch_log_for_result)
-
-    if [ "$RESULT" = "STORY_COMPLETE" ]; then
-        update_status "✅ IMPL COMMIT PASSED: Tests pass (TDD green phase)"
-        echo ""
-        update_status "🚀 PUSHING"
-        git push origin HEAD
-        update_status "✅ COMPLETE: impl: commit pushed"
-    elif [ "$RESULT" = "ERROR" ]; then
-        update_status "❌ IMPL COMMIT FAILED: Tests still failing"
-        echo "   Your impl: commit should make tests pass."
-        exit 1
-    else
-        update_status "❌ IMPL COMMIT FAILED: Timeout waiting for test result"
-        exit 1
-    fi
-
-elif [[ "$COMMIT_MSG" == refactor:* ]]; then
-    echo ""
-    update_status "📋 REFACTOR COMMIT: Running all tests (expect PASS)"
-    echo ""
-
-    update_status "🤖 DEPLOYING_AUTOMATED"
-    ./scripts/deploy-test.sh
-
-    if [ $? -ne 0 ]; then
-        echo ""
-        update_status "❌ FAILED: Automated deploy failed"
-        exit 1
-    fi
-
-    echo ""
-    update_status "⏳ WATCHING LOG (automated - expecting Story complete)"
-    RESULT=$(watch_log_for_result)
-
-    if [ "$RESULT" = "ERROR" ]; then
-        update_status "❌ REFACTOR FAILED: Automated tests failed"
-        echo "   Refactoring should not break tests."
-        exit 1
-    elif [ "$RESULT" = "TIMEOUT" ]; then
-        update_status "❌ REFACTOR FAILED: Timeout waiting for automated test result"
-        exit 1
-    fi
-    update_status "✅ AUTOMATED_PASSED"
-
-    echo ""
-    update_status "👤 DEPLOYING_MANUAL"
-    ./scripts/deploy-test.sh --manual
-
-    echo ""
-    update_status "⏳ WATCHING LOG (manual - expecting Story complete)"
-    RESULT=$(watch_log_for_result)
-
-    if [ "$RESULT" = "ERROR" ]; then
-        update_status "❌ REFACTOR FAILED: Manual tests failed"
-        echo "   Refactoring should not break tests."
-        exit 1
-    elif [ "$RESULT" = "TIMEOUT" ]; then
-        update_status "❌ REFACTOR FAILED: Timeout waiting for manual test result"
-        exit 1
-    fi
-    update_status "✅ MANUAL_PASSED"
-
-    echo ""
-    update_status "🚀 PUSHING"
-    git push origin HEAD
-    update_status "✅ COMPLETE: refactor: commit pushed"
-
+if [ $? -eq 0 ]; then
+    echo "✅ Pushed."
 else
-    echo ""
-    echo "⚠️  Unknown commit type. No tests run."
-    echo ""
+    echo "❌ Push failed."
+    exit 1
 fi

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -24,5 +24,4 @@ if [[ "$COMMIT_MSG" == plan:* ]]; then
     exit 0
 fi
 
-# test/impl/refactor - allow push
 exit 0

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+COMMIT_HASH=$(git rev-parse HEAD)
 COMMIT_MSG=$(git log -1 --format=%s)
 
 if [[ "$COMMIT_MSG" == plan:* ]]; then
-    echo "✅ plan: commit - no additional validation"
+    if [ ! -f "$REPO_ROOT/.plan-accepted" ]; then
+        echo ""
+        echo "❌ Plan not accepted. Use ExitPlanMode in Claude Code."
+        echo ""
+        exit 1
+    fi
+    if [ "$(cat "$REPO_ROOT/.plan-accepted")" != "$COMMIT_HASH" ]; then
+        echo ""
+        echo "❌ Plan accepted for different commit."
+        echo "   Expected: $COMMIT_HASH"
+        echo "   Found:    $(cat "$REPO_ROOT/.plan-accepted")"
+        echo ""
+        exit 1
+    fi
+    echo "✅ Plan accepted."
+    rm -f "$REPO_ROOT/.plan-accepted"
     exit 0
-
-elif [[ "$COMMIT_MSG" == test:* ]]; then
-    echo "✅ test: commit - validated by post-commit"
-    exit 0
-
-elif [[ "$COMMIT_MSG" == impl:* ]]; then
-    echo "✅ impl: commit - validated by post-commit"
-    exit 0
-
-elif [[ "$COMMIT_MSG" == refactor:* ]]; then
-    echo "✅ refactor: commit - validated by post-commit"
-    exit 0
-
-else
-    echo "⚠️  Unknown commit type: $COMMIT_MSG"
-    echo "   Commit types: plan: | test: | impl: | refactor:"
-    exit 1
 fi
+
+# test/impl/refactor - allow push
+exit 0

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -1,41 +1,25 @@
 #!/bin/bash
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-COMMIT_HASH=$(git rev-parse HEAD)
+COMMIT_MSG=$(git log -1 --format=%s)
 
-AUTOMATED_FILE="$REPO_ROOT/.test-passed-automated"
+if [[ "$COMMIT_MSG" == plan:* ]]; then
+    echo "✅ plan: commit - no additional validation"
+    exit 0
 
-if [ ! -f "$AUTOMATED_FILE" ]; then
-    echo "❌ Automated tests not run for this commit."
-    echo "   Run: ./scripts/deploy-test.sh"
+elif [[ "$COMMIT_MSG" == test:* ]]; then
+    echo "✅ test: commit - validated by post-commit"
+    exit 0
+
+elif [[ "$COMMIT_MSG" == impl:* ]]; then
+    echo "✅ impl: commit - validated by post-commit"
+    exit 0
+
+elif [[ "$COMMIT_MSG" == refactor:* ]]; then
+    echo "✅ refactor: commit - validated by post-commit"
+    exit 0
+
+else
+    echo "⚠️  Unknown commit type: $COMMIT_MSG"
+    echo "   Commit types: plan: | test: | impl: | refactor:"
     exit 1
 fi
-
-AUTOMATED_HASH=$(cat "$AUTOMATED_FILE")
-if [ "$AUTOMATED_HASH" != "$COMMIT_HASH" ]; then
-    echo "❌ Automated tests not passed for HEAD ($COMMIT_HASH)"
-    echo "   Marker has: $AUTOMATED_HASH"
-    echo "   Run: ./scripts/deploy-test.sh"
-    exit 1
-fi
-
-MANUAL_FILE="$REPO_ROOT/.test-passed-manual"
-
-if [ ! -f "$MANUAL_FILE" ]; then
-    echo "❌ Manual tests not run for this commit."
-    echo "   Run: ./scripts/deploy-test.sh --manual"
-    exit 1
-fi
-
-MANUAL_HASH=$(cat "$MANUAL_FILE")
-if [ "$MANUAL_HASH" != "$COMMIT_HASH" ]; then
-    echo "❌ Manual tests not passed for HEAD ($COMMIT_HASH)"
-    echo "   Marker has: $MANUAL_HASH"
-    echo "   Run: ./scripts/deploy-test.sh --manual"
-    exit 1
-fi
-
-echo "✅ All tests passed for $COMMIT_HASH"
-echo "   Pushing..."
-
-exit 0

--- a/tests/GATEKEEPER_SPEC.md
+++ b/tests/GATEKEEPER_SPEC.md
@@ -1,0 +1,21 @@
+# Gatekeeper Test Specification
+
+## TEST 1: Plan requires acceptance
+BEHAVIOR: plan: commit cannot push until ExitPlanMode creates .plan-accepted
+TIMING: Push must fail immediately without .plan-accepted
+FAIL IF: Push succeeds without .plan-accepted file containing correct hash
+
+## TEST 2: Acceptance enables push
+BEHAVIOR: After ExitPlanMode, .plan-accepted contains HEAD hash, push succeeds
+TIMING: Push should succeed immediately after acceptance
+FAIL IF: Push fails after valid .plan-accepted exists
+
+## TEST 3: Test/impl/refactor auto-push
+BEHAVIOR: test:/impl:/refactor: commits push immediately (tests disabled)
+TIMING: Push happens automatically in post-commit
+FAIL IF: Push requires manual intervention
+
+## TEST 4: Order enforcement
+BEHAVIOR: Commits must follow order: plan → test → impl → refactor
+TIMING: commit-msg rejects out-of-order commits
+FAIL IF: impl: allowed before test:, or test: allowed before plan:

--- a/tests/test-gatekeeper.sh
+++ b/tests/test-gatekeeper.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TEST_PLAN_BLOCKED_MARKER="✓ TEST[1] PASSED: plan_blocked_without_acceptance"
+TEST_ACCEPTANCE_WORKS_MARKER="✓ TEST[2] PASSED: acceptance_enables_push"
+TEST_AUTO_PUSH_MARKER="✓ TEST[3] PASSED: non_plan_auto_pushes"
+TEST_ORDER_MARKER="✓ TEST[4] PASSED: order_enforced"
+
+pre() {
+    local condition=$1
+    local message=$2
+    if [ "$condition" != "true" ]; then
+        echo "PRE: $message"
+        exit 1
+    fi
+}
+
+post() {
+    local condition=$1
+    local message=$2
+    if [ "$condition" != "true" ]; then
+        echo "POST: $message"
+        exit 1
+    fi
+}
+
+inv() {
+    local condition=$1
+    local message=$2
+    if [ "$condition" != "true" ]; then
+        echo "INV: $message"
+        exit 1
+    fi
+}


### PR DESCRIPTION
## Summary
- Simplified post-commit and pre-push hooks
- plan: commits wait for ExitPlanMode acceptance before push
- test/impl/refactor: commits push immediately (tests disabled)
- Added test specification for future use

## Changes
- `scripts/hooks/post-commit.sh`: Plan waits, others auto-push
- `scripts/hooks/pre-push.sh`: Plan checks .plan-accepted, others allow
- `tests/GATEKEEPER_SPEC.md`: Test specification
- `tests/test-gatekeeper.sh`: Contract functions for tests

## Test plan
- [x] plan: commit waits for acceptance message
- [x] test: commit auto-pushes
- [x] impl: commit auto-pushes
- [x] refactor: commit auto-pushes
- [ ] Future: Re-enable test enforcement when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)