### PR TITLE
Simplify workflow: plan acceptance gatekeeper

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,24 +1,25 @@
 # Claude Code Instructions
 
-## PLAN ACCEPTANCE (REQUIRED BEFORE PUSH)
+## PLAN ACCEPTANCE (AUTO ON EXIT PLAN MODE)
 
-**Cannot push without accepted plan.**
+**When you exit plan mode (ExitPlanMode), plan is auto-accepted.**
 
-When user says "accept plan":
-1. Write current branch name to `.plan-accepted` file
-2. Confirm: "Plan accepted for <branch>. You can now push."
+Hook writes `.plan-accepted` with branch name automatically.
 
-```bash
-echo "$(git branch --show-current)" > .plan-accepted
-```
-
-Pre-push hook checks this marker. No marker = no push.
+Flow:
+1. Enter plan mode → write plan → user approves
+2. Exit plan mode → hook auto-accepts
+3. Push allowed
 
 ## BRANCH PROTECTION
 
 `development` and `main` are protected. PRs required.
 
-Workflow: feature branch → accept plan → push → PR → merge
+## PRE-PUSH RULES
+
+1. Plan must be accepted (via ExitPlanMode)
+2. First push must be a `plan:` commit
+3. After plan pushed, all pushes allowed
 
 ## SKILLS
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,116 +1,27 @@
-# Global Claude Code Instructions
+# Claude Code Instructions
+
+## PLAN ACCEPTANCE (REQUIRED BEFORE PUSH)
+
+**Cannot push without accepted plan.**
+
+When user says "accept plan":
+1. Write current branch name to `.plan-accepted` file
+2. Confirm: "Plan accepted for <branch>. You can now push."
+
+```bash
+echo "$(git branch --show-current)" > .plan-accepted
+```
+
+Pre-push hook checks this marker. No marker = no push.
 
 ## BRANCH PROTECTION
 
-**`development` is protected. No direct commits.**
+`development` and `main` are protected. PRs required.
 
-```
-Workflow: worktree → test → push → PR → merge → deploy
-Skills:   /deploy-test (iPhone)  /deploy (iPad)  /crash-logs
-```
+Workflow: feature branch → accept plan → push → PR → merge
 
-Local pre-commit hook blocks commits to development/main.
-GitHub blocks direct push. PRs required.
+## SKILLS
 
-## MAIN AGENT = COORDINATOR ONLY
-
-**Zero tolerance. Main context is sacred.**
-
-### Main Agent Does:
-- Talk to user
-- Spawn agents
-- Collect summaries
-- Make decisions
-
-### Main Agent NEVER Does:
-- Bash commands (use run_in_background: true)
-- Read files over 100 lines (spawn Explore agent)
-- Search codebases (spawn Explore agent)
-- Web searches (spawn Task agent)
-- Multi-file edits (spawn general-purpose agent)
-- Anything that produces output
-
-### Every Single Bash → Background
-```
-run_in_background: true
-```
-No exceptions. Even `ls`. Even `git status`. Everything.
-
-### Every Exploration → Agent
-```
-Task tool → subagent_type: "Explore"
-```
-Agent reads, searches, returns 1-paragraph summary.
-
-### Why This Extreme?
-- 1 deploy with logs = 50k tokens = conversation over
-- 1 file read = 2k tokens = wasted forever
-- Background agent uses ITS context, returns 100 tokens
-- Main stays at 5k tokens, lasts entire session
-- User always has responsive agent ready to talk
-
-### The Math
-Without this: 200k context ÷ 50k per task = 4 tasks then dead
-With this: 200k context ÷ 500 per task = 400 tasks, immortal coordinator
-
-### Pattern
-User speaks → Spawn agent → Keep talking → Get summary → Repeat forever
-
-## TDD COMMIT ENFORCEMENT
-
-**Every commit must have prefix: plan: | test: | impl: | refactor:**
-
-commit-msg hook validates via headless Claude agent.
-
-### Universal Rules (Uncle Bob)
-
-1. **BRANCH = TOPIC** - changes must relate to branch name
-2. **ONE THING** - focused on single behavior
-3. **MESSAGE MATCH** - describes exactly what diff does
-
-### plan: - Design
-
-PASS if diff adds:
-- Design documents or architecture decisions
-- Plan files (.md planning docs)
-- TODO lists or task breakdowns
-- Interface definitions (what, not how)
-
-FAIL if:
-- Contains implementation code
-- Contains test code (contracts)
-- No planning content added
-
-### test: - Specification
-
-PASS if diff adds:
-- pre(condition, message) - precondition guards
-- post(condition, message) - postcondition guards
-- inv(condition, message) - invariant guards
-- STORY test case entries
-- TEST_*_MARKER definitions
-- Test functions that emit markers
-
-FAIL if:
-- None of above added
-- ANY log() that isn't a test marker
-- Business logic
-
-### impl: - Implementation
-
-PASS if diff adds:
-- log() calls (the story/narrative)
-- Logic that makes contracts pass
-
-FAIL if:
-- No log() calls added
-- Only contracts (that's test:)
-
-### refactor: - Cleanup
-
-PASS if:
-- ZERO comments in added lines
-- Code is clean and readable
-
-FAIL if:
-- Any comment syntax in added lines
+- `/deploy` - Production deploy to iPad
+- `/deploy-test` - Test deploy to iPhone
+- `/crash-logs` - Analyze crash logs

--- a/.claude/hooks/limit-main-agent.sh
+++ b/.claude/hooks/limit-main-agent.sh
@@ -6,12 +6,6 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 LOG_FILE="/tmp/hook-coordinator.log"
 
-# Check if in worktree
-IS_WORKTREE=false
-if [[ "$CWD" == *"/worktrees/"* ]]; then
-    IS_WORKTREE=true
-fi
-
 BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "unknown")
 
 # Log
@@ -21,62 +15,21 @@ BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "unknown")
     echo "TOOL: $TOOL_NAME"
     echo "CWD: $CWD"
     echo "BRANCH: $BRANCH"
-    echo "IS_WORKTREE: $IS_WORKTREE"
 } >> "$LOG_FILE"
 
 # =============================================================================
-# RULE 1: Task must have run_in_background: true
+# RULE: ExitPlanMode auto-accepts the plan
 # =============================================================================
-if [ "$TOOL_NAME" = "Task" ]; then
-    RUN_IN_BG=$(echo "$INPUT" | jq -r '.tool_input.run_in_background // false')
-    if [ "$RUN_IN_BG" = "true" ]; then
-        echo "RESULT: ALLOWED (Task with run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        exit 0
-    else
-        echo "RESULT: BLOCKED (Task without run_in_background)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        echo "" >&2
-        echo "BLOCKED: Task requires run_in_background: true" >&2
-        echo "You are the coordinator. Spawn background agents, don't block." >&2
-        exit 2
-    fi
+if [ "$TOOL_NAME" = "ExitPlanMode" ]; then
+    echo "$BRANCH" > "$CWD/.plan-accepted"
+    echo "RESULT: ALLOWED (ExitPlanMode - plan accepted for $BRANCH)" >> "$LOG_FILE"
+    echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
+    echo "✅ Plan accepted for branch: $BRANCH" >&2
+    exit 0
 fi
 
 # =============================================================================
-# RULE 2: Bash - allow foreground for quick commands
-# =============================================================================
-# Foreground bash allowed. Deploys run in background via their own scripts.
-
-# =============================================================================
-# RULE 3: Edit/Write must be in worktree
-# =============================================================================
-if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
-    # Exception: Allow writes to .claude/plans/ for plan mode
-    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-    if [[ "$FILE_PATH" == *"/.claude/plans/"* ]]; then
-        echo "RESULT: ALLOWED ($TOOL_NAME to plans directory)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        exit 0
-    fi
-
-    if [ "$IS_WORKTREE" = "true" ]; then
-        echo "RESULT: ALLOWED ($TOOL_NAME in worktree)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        exit 0
-    else
-        echo "RESULT: BLOCKED ($TOOL_NAME not in worktree)" >> "$LOG_FILE"
-        echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"
-        echo "" >&2
-        echo "BLOCKED: $TOOL_NAME not allowed outside worktree." >&2
-        echo "CWD: $CWD (branch: $BRANCH)" >&2
-        echo "Switch to worktree: cd /Users/felixlunzenfichter/Documents/worktrees/<branch>" >&2
-        exit 2
-    fi
-fi
-
-# =============================================================================
-# RULE 4: Everything else allowed
+# Everything else allowed (restrictions disabled for now)
 # =============================================================================
 echo "RESULT: ALLOWED ($TOOL_NAME)" >> "$LOG_FILE"
 echo "════════════════════════════════════════════════════════════════" >> "$LOG_FILE"

--- a/.claude/plans/plan-acceptance-gatekeeper.md
+++ b/.claude/plans/plan-acceptance-gatekeeper.md
@@ -1,0 +1,16 @@
+# Plan: Plan Acceptance Gatekeeper
+
+## STORY
+
+| Step | Command | Result |
+|------|---------|--------|
+| 0 | (wait) | handshake |
+| 1 | "Create plan" | rejected |
+| 2 | "Accept plan" | accepted |
+
+## Files
+
+| File | Change |
+|------|--------|
+| `RealtimeClaude/Logger.swift` | Add STORY, markers, createPlan(), acceptPlan() |
+| `scripts/mac-server.js` | Add create_plan and accept_plan handlers |

--- a/.claude/plans/tdd-trace-system.md
+++ b/.claude/plans/tdd-trace-system.md
@@ -1,0 +1,58 @@
+# Plan: TDD Trace System
+
+## Goal
+Prove test execution through committed log traces. No marker files.
+
+## Log Format (with contracts)
+
+```
+time | mode | device | type | component | file | function | message
+```
+
+| Field | Values | Determined By |
+|-------|--------|---------------|
+| mode | PROD / TEST / TEST-MANUAL | IS_TEST, MANUAL_TESTING env vars |
+| device | iPhone / iPad | PORT (9999=iPhone, 8082=iPad) |
+| component | MAC / iOS | fileName |
+
+### Contracts
+
+```
+PRE: type in {log, error}
+PRE: timestamp != null
+PRE: fileName != null
+PRE: functionName != null
+PRE: message != undefined
+
+POST: result.split(' | ').length = 8
+POST: mode in {PROD, TEST, TEST-MANUAL}
+POST: device in {iPhone, iPad}
+POST: component in {MAC, iOS}
+```
+
+## TDD Commit Flow
+
+| Commit | Deploy | Wait For | Evidence |
+|--------|--------|----------|----------|
+| test: | automated | error in log | commit code + log |
+| impl: | automated | "Story complete" | commit code + log |
+| refactor: | manual | "Story complete" | commit + delete traces |
+
+## Protection
+
+- Block --no-verify in Claude hooks
+- TDD order: plan -> test -> impl -> refactor
+
+## Files to Change
+
+1. `scripts/mac-server.js` - log format with contracts
+2. `scripts/hooks/post-commit.sh` - trace commit flow
+3. `.claude/hooks/limit-main-agent.sh` - block --no-verify
+
+## Implementation Steps
+
+1. Create worktree from development
+2. test: Add log format contracts (expect failure - old format has 6 parts)
+3. impl: Fix formatLogLine to produce 8 parts
+4. refactor: Clean up
+5. Push, PR, merge

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,17 @@
-{"enableAllProjectMcpServers": false}
+{
+  "enableAllProjectMcpServers": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/limit-main-agent.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,1 @@
-{
-  "enableAllProjectMcpServers": false,
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Edit|Write|Bash|WebFetch|WebSearch|Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/limit-main-agent.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
+{"enableAllProjectMcpServers": false}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ whisper-venv-312/
 .test-passed-manual
 .test-status
 .plan-accepted
+test-no-verify
+worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ whisper-venv-312/
 .test-passed-automated
 .test-passed-manual
 .test-status
+.plan-accepted

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ iOS app connected to OpenAI Realtime API.
 
 Realtime API handles audio input/output. Has function calling for creating and sending prompts to Claude.
 
-Mac server receives prompts from iOS, forwards to Claude, sends back Claude's assistant messages so realtime API can narrate/summarize them.
+Mac server receives prompts from iOS, forwards to Claude, sends back Claude's assistant messages so realtime API can narrate/summarize them.# test

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -1,41 +1,52 @@
 #!/bin/bash
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-COMMIT_HASH=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+MARKER=".plan-accepted"
 
-AUTOMATED_FILE="$REPO_ROOT/.test-passed-automated"
-
-if [ ! -f "$AUTOMATED_FILE" ]; then
-    echo "❌ Automated tests not run for this commit."
-    echo "   Run: ./scripts/deploy-test.sh"
+# Block protected branches
+if [ "$BRANCH" = "development" ] || [ "$BRANCH" = "main" ]; then
+    echo "❌ Cannot push directly to $BRANCH"
     exit 1
 fi
 
-AUTOMATED_HASH=$(cat "$AUTOMATED_FILE")
-if [ "$AUTOMATED_HASH" != "$COMMIT_HASH" ]; then
-    echo "❌ Automated tests not passed for HEAD ($COMMIT_HASH)"
-    echo "   Marker has: $AUTOMATED_HASH"
-    echo "   Run: ./scripts/deploy-test.sh"
+# Check 1: Plan must be accepted
+if [ ! -f "$MARKER" ]; then
+    echo "❌ No plan accepted."
+    echo "   Say 'accept plan' to Claude first."
     exit 1
 fi
 
-MANUAL_FILE="$REPO_ROOT/.test-passed-manual"
-
-if [ ! -f "$MANUAL_FILE" ]; then
-    echo "❌ Manual tests not run for this commit."
-    echo "   Run: ./scripts/deploy-test.sh --manual"
+ACCEPTED_BRANCH=$(cat "$MARKER")
+if [ "$ACCEPTED_BRANCH" != "$BRANCH" ]; then
+    echo "❌ Plan accepted for '$ACCEPTED_BRANCH', not '$BRANCH'"
     exit 1
 fi
 
-MANUAL_HASH=$(cat "$MANUAL_FILE")
-if [ "$MANUAL_HASH" != "$COMMIT_HASH" ]; then
-    echo "❌ Manual tests not passed for HEAD ($COMMIT_HASH)"
-    echo "   Marker has: $MANUAL_HASH"
-    echo "   Run: ./scripts/deploy-test.sh --manual"
+# Check 2: Is plan already pushed?
+REMOTE_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null)
+
+if [ -z "$REMOTE_EXISTS" ]; then
+    # Branch not on remote - this is first push
+    # Only allow if pushing a plan commit
+    COMMITS=$(git log origin/development..HEAD --oneline 2>/dev/null || git log HEAD --oneline)
+    if echo "$COMMITS" | grep -q "^[a-f0-9]* plan:"; then
+        echo "✅ Pushing plan commit..."
+        exit 0
+    else
+        echo "❌ First push must be a plan commit."
+        echo "   Commit with 'plan: ...' message first."
+        exit 1
+    fi
+fi
+
+# Branch exists on remote - check if plan was pushed
+PLAN_ON_REMOTE=$(git log "origin/$BRANCH" --oneline 2>/dev/null | grep "^[a-f0-9]* plan:" | head -1)
+
+if [ -z "$PLAN_ON_REMOTE" ]; then
+    echo "❌ No plan commit on remote yet."
+    echo "   Push a 'plan: ...' commit first."
     exit 1
 fi
 
-echo "✅ All tests passed for $COMMIT_HASH"
-echo "   Pushing..."
-
+echo "✅ Plan accepted and pushed. Pushing..."
 exit 0


### PR DESCRIPTION
## Summary
- Disabled all restrictive hooks (pre-commit, commit-msg, post-commit)
- Simplified pre-push to only require plan acceptance
- Added auto-accept hook on ExitPlanMode

## Flow
1. Enter plan mode → write plan → user approves
2. Exit plan mode → hook auto-writes `.plan-accepted`
3. First push must be `plan:` commit
4. After plan pushed, all pushes allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)