### PR TITLE
Block git hook bypass for Claude

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if echo "$COMMAND" | grep -qE 'git\s+(commit|push|merge|rebase|cherry-pick|am).*--no-verify|git\s+.*--no-verify.*(commit|push|merge|rebase|cherry-pick|am)'; then
+    echo "❌ --no-verify is not allowed." >&2
+    echo "" >&2
+    echo "   Claude must use hooks. Only the user can bypass." >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-no-verify.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Adds PreToolUse hook that blocks the flag that bypasses git hooks
- Prevents Claude from skipping commit, push, merge, rebase hooks
- Hook is in `.claude/hooks/block-no-verify.sh`, registered in team settings

## Test plan
- [x] Echo commands with the flag in string pass (not actual git commands)
- [x] Git commit with bypass flag is blocked
- [x] Git push with bypass flag is blocked
- [x] Normal git commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)