### PR TITLE
feat: inline diffs for unpushed commits

### DIFF
--- a/scripts/get-diff.sh
+++ b/scripts/get-diff.sh
@@ -10,10 +10,7 @@ fi
 cd "$REPO_PATH" || exit 1
 
 python3 << 'PYTHON'
-import json, os, time, subprocess
-
-now = time.time()
-cutoff = now - 300
+import subprocess
 
 def run(cmd):
     try:
@@ -22,89 +19,83 @@ def run(cmd):
         return ""
 
 current_branch = run("git rev-parse --abbrev-ref HEAD") or "unknown"
-
-agents_by_branch = {}
-for proj_dir in os.listdir(os.path.expanduser("~/.claude/projects")):
-    index_path = os.path.expanduser(f"~/.claude/projects/{proj_dir}/sessions-index.json")
-    if os.path.exists(index_path):
-        try:
-            with open(index_path) as f:
-                data = json.load(f)
-            for entry in data.get("entries", []):
-                mtime = entry.get("fileMtime", 0) / 1000
-                agent_branch = entry.get("gitBranch", "") or "unknown"
-                if mtime > cutoff:
-                    prompt = entry.get("firstPrompt", "")[:40].replace("\n", " ").strip()
-                    ago = int(now - mtime)
-                    if agent_branch not in agents_by_branch:
-                        agents_by_branch[agent_branch] = []
-                    agents_by_branch[agent_branch].append((ago, prompt))
-        except:
-            pass
-
-branch = current_branch
-remote_head = run("git rev-parse origin/" + branch + " 2>/dev/null")
+dev_head = run("git rev-parse origin/development 2>/dev/null")
 local_head = run("git rev-parse HEAD")
 
-commits = []
-log = run("git log --format='%h %d %s'")
-for line in log.split('\n'):
-    if line.strip():
-        commits.append(line.strip())
-
-working = []
-status = run("git status --porcelain")
-for line in status.split('\n'):
-    if not line.strip():
-        continue
-    code = line[:2]
-    filepath = line[3:]
-
-    if code[0] == '?' or code[1] == '?':
-        stat = run(f"wc -l < '{filepath}' 2>/dev/null") or "0"
-        working.append(f"? {filepath} (+{stat.strip()})")
-    else:
-        diff_stat = run(f"git diff --numstat '{filepath}' 2>/dev/null")
-        if diff_stat:
-            parts = diff_stat.split()
-            if len(parts) >= 2:
-                added, removed = parts[0], parts[1]
-                working.append(f"M {filepath} (+{added} -{removed})")
-        else:
-            diff_stat = run(f"git diff --cached --numstat '{filepath}' 2>/dev/null")
-            if diff_stat:
-                parts = diff_stat.split()
-                if len(parts) >= 2:
-                    added, removed = parts[0], parts[1]
-                    working.append(f"M {filepath} (+{added} -{removed})")
+unpushed_commits = []
+if dev_head and current_branch != "development":
+    log = run(f"git log origin/development..HEAD --format='%h|%s'")
+    for line in log.split('\n'):
+        if line.strip() and '|' in line:
+            hash_part, msg = line.split('|', 1)
+            unpushed_commits.append((hash_part.strip(), msg.strip()))
 
 lines = []
 
-for br in sorted(agents_by_branch.keys(), key=lambda b: (b != current_branch, b)):
-    agents = agents_by_branch[br]
-    marker = "★" if br == current_branch else "○"
-    lines.append(f"├─ {marker} {br}")
-    for ago, prompt in sorted(agents):
-        if ago < 60:
-            time_str = f"{ago}s"
-        else:
-            time_str = f"{ago // 60}m{ago % 60:02d}s"
-        lines.append(f"│  ├─ ● {time_str} \"{prompt}...\"")
+if unpushed_commits:
+    lines.append(f"├─ ★ {current_branch} ({len(unpushed_commits)} ahead)")
     lines.append("│")
 
-if working:
+    for i, (commit_hash, msg) in enumerate(unpushed_commits):
+        is_last_commit = (i == len(unpushed_commits) - 1)
+        connector = "└─" if is_last_commit else "├─"
+        cont = " " if is_last_commit else "│"
+
+        lines.append(f"│  {connector} {commit_hash}: \"{msg}\"")
+
+        diff = run(f"git show {commit_hash} --format='' --no-color -- | head -50")
+        if diff:
+            diff_lines = diff.split('\n')
+            for dl in diff_lines:
+                if dl.startswith('+') and not dl.startswith('+++'):
+                    lines.append(f"│  {cont}    + {dl[1:60]}")
+                elif dl.startswith('-') and not dl.startswith('---'):
+                    lines.append(f"│  {cont}    - {dl[1:60]}")
+
+        if not is_last_commit:
+            lines.append("│  │")
+
+    lines.append("│")
+
+status = run("git status --porcelain")
+working_files = []
+for line in status.split('\n'):
+    if line.strip():
+        filepath = line[3:]
+        working_files.append(filepath)
+
+if working_files:
     lines.append("├─ Working")
-    for i, w in enumerate(working):
-        prefix = "│  └─ " if i == len(working) - 1 else "│  ├─ "
-        lines.append(prefix + w)
+
+    for i, filepath in enumerate(working_files):
+        is_last = (i == len(working_files) - 1)
+        connector = "└─" if is_last else "├─"
+        cont = " " if is_last else "│"
+
+        lines.append(f"│  {connector} {filepath}")
+
+        diff = run(f"git diff HEAD -- '{filepath}' 2>/dev/null | head -30")
+        if not diff:
+            diff = run(f"git diff --cached -- '{filepath}' 2>/dev/null | head -30")
+
+        if diff:
+            diff_lines = diff.split('\n')
+            for dl in diff_lines:
+                if dl.startswith('+') and not dl.startswith('+++'):
+                    lines.append(f"│  {cont}    + {dl[1:60]}")
+                elif dl.startswith('-') and not dl.startswith('---'):
+                    lines.append(f"│  {cont}    - {dl[1:60]}")
+
     lines.append("│")
 
-if commits:
-    for i, c in enumerate(commits):
-        prefix = "└─ " if i == len(commits) - 1 else "├─ "
-        lines.append(prefix + c)
-else:
-    lines.append("└─ (no commits)")
+dev_log = run("git log origin/development --format='%h %s' -5")
+if dev_log:
+    dev_commits = dev_log.split('\n')
+    for i, c in enumerate(dev_commits):
+        if c.strip():
+            is_last = (i == len(dev_commits) - 1)
+            prefix = "└─" if is_last else "├─"
+            lines.append(f"{prefix} {c.strip()}")
 
 print('\n'.join(lines))
 PYTHON


### PR DESCRIPTION
## Summary
- Shows inline diffs for commits ahead of development
- Shows inline diffs for working directory changes
- Development commits shown as headers only (no diffs)

## Example Output
```
├─ ★ feature-x (2 ahead)
│
│  └─ abc123: "add auth"
│       + guard let token = ...
│       + error("No token")
│
├─ Working
│  └─ Config.swift
│       - DEBUG = false
│       + DEBUG = true
│
├─ f1e7fdbd Merge PR #36
└─ ad526b42 refactor: tree view
```

## Test plan
- [x] Run `./scripts/get-diff.sh` manually
- [ ] Deploy to iPhone with `/deploy-test`
- [ ] Verify format in diff view

🤖 Generated with [Claude Code](https://claude.com/claude-code)