### PR TITLE
fix: enforce first commit on branch must be plan commit

### DIFF
--- a/.claude/plans/fix-first-commit-check.md
+++ b/.claude/plans/fix-first-commit-check.md
@@ -1,0 +1,25 @@
+# Fix First Commit Check
+
+## Problem
+
+The pre-push hook checks if ANY commit has `plan:` prefix, not if the FIRST commit is a plan.
+
+## Current (bug)
+
+```bash
+COMMITS=$(git log origin/development..HEAD --oneline)
+if echo "$COMMITS" | grep -q "^[a-f0-9]* plan:"; then
+```
+
+## Fix
+
+```bash
+FIRST_COMMIT=$(git log origin/development..HEAD --oneline --reverse | head -1)
+if echo "$FIRST_COMMIT" | grep -q "^[a-f0-9]* plan:"; then
+```
+
+`--reverse` shows oldest first, `head -1` gets the first commit.
+
+## File
+
+`scripts/hooks/pre-push.sh`

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -31,17 +31,17 @@ fi
 REMOTE_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null)
 
 if [ -z "$REMOTE_EXISTS" ]; then
-    # Branch not on remote - this is first push
-    # Only allow if pushing a plan commit
-    COMMITS=$(git log origin/development..HEAD --oneline 2>/dev/null || git log HEAD --oneline)
-    if echo "$COMMITS" | grep -q "^[a-f0-9]* plan:"; then
+    FIRST_COMMIT=$(git log origin/development..HEAD --oneline --reverse 2>/dev/null | head -1)
+    if echo "$FIRST_COMMIT" | grep -q "^[a-f0-9]* plan:"; then
         echo "✅ Pushing plan commit..."
         exit 0
     else
-        echo "❌ First push must be a plan: commit."
+        echo "❌ First commit on branch must be a plan: commit."
         echo ""
-        echo "   Claude: Create a commit with message starting with 'plan:'"
-        echo "   Example: git commit -m 'plan: implement feature X'"
+        echo "   First commit: $FIRST_COMMIT"
+        echo ""
+        echo "   Claude: The FIRST commit on the branch must start with 'plan:'"
+        echo "   You may need to rebase or start fresh."
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary
- Pre-push hook was checking if ANY commit has `plan:` prefix
- Now checks if FIRST commit (oldest on branch) has `plan:` prefix
- Uses `--reverse | head -1` to get the first commit

## Test plan
- [ ] Create branch with impl commit first, verify push blocked
- [ ] Create branch with plan commit first, verify push allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)