### PR TITLE
fix: check first commit on branch, not any commit

### DIFF
--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -32,9 +32,12 @@ REMOTE_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null)
 
 if [ -z "$REMOTE_EXISTS" ]; then
     # Branch not on remote - this is first push
-    # Only allow if pushing a plan commit
-    COMMITS=$(git log origin/development..HEAD --oneline 2>/dev/null || git log HEAD --oneline)
-    if echo "$COMMITS" | grep -q "^[a-f0-9]* plan:"; then
+    # First commit on branch must be a plan commit
+    FIRST_COMMIT=$(git log origin/development..HEAD --oneline --reverse 2>/dev/null | head -1)
+    if [ -z "$FIRST_COMMIT" ]; then
+        FIRST_COMMIT=$(git log HEAD --oneline --reverse | head -1)
+    fi
+    if echo "$FIRST_COMMIT" | grep -q "^[a-f0-9]* plan:"; then
         echo "✅ Pushing plan commit..."
         exit 0
     else


### PR DESCRIPTION
## Summary
- Pre-push hook was checking if ANY commit had `plan:` prefix
- Now checks if the FIRST commit on the branch has `plan:` prefix
- Uses `--reverse | head -1` to get oldest commit first

## Test plan
- [ ] Create branch with impl commit first → should block
- [ ] Create branch with plan commit first → should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)