### PR TITLE
feat: plan acceptance checkmark with conditional visibility

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,12 @@
 # Claude Code Instructions
 
+## NEVER KILL PRODUCTION
+
+- **iPad = production (port 8082)** - NEVER KILL
+- **iPhone = test (port 9999)** - safe to kill
+
+When killing mac-server: `lsof -ti :9999 | xargs kill` NOT `pkill -f mac-server`
+
 ## PLAN ACCEPTANCE (AUTO ON EXIT PLAN MODE)
 
 **When you exit plan mode (ExitPlanMode), plan is auto-accepted.**
@@ -21,8 +28,20 @@ Flow:
 2. First push must be a `plan:` commit
 3. After plan pushed, all pushes allowed
 
+## TEST SYSTEM
+
+| Device | Port | Purpose |
+|--------|------|---------|
+| iPhone | 9999 | Test builds (safe to break) |
+| iPad | 8082 | Production (NEVER break) |
+
+**Workflow:**
+1. Test on iPhone (port 9999) - automated then manual
+2. Tests pass → PR to development
+3. Merge → deploy to iPad (port 8082)
+
 ## SKILLS
 
-- `/deploy` - Production deploy to iPad
-- `/deploy-test` - Test deploy to iPhone
-- `/crash-logs` - Analyze crash logs
+- `/deploy` - Production deploy to iPad (port 8082)
+- `/deploy-test` - Test deploy to iPhone (port 9999)
+- `/crash-logs` - Analyze crash logs from iPhone

--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,0 +1,21 @@
+---
+name: executor
+description: Execute code changes. Use this agent to implement plans - it can edit files, run commands, and make changes. The main agent is in plan mode and cannot edit, so delegate all code changes to this executor.
+permissionMode: bypassPermissions
+model: inherit
+---
+
+You are an executor agent. Your job is to implement code changes as directed.
+
+You receive instructions from the main agent (which is in plan-only mode and cannot edit files).
+
+Your capabilities:
+- Edit and write files
+- Run bash commands
+- Make code changes
+
+Guidelines:
+- Follow the plan exactly as given
+- Report what you changed
+- If something is unclear, return and ask for clarification
+- Keep changes minimal and focused

--- a/.claude/plans/test-checkmark.md
+++ b/.claude/plans/test-checkmark.md
@@ -1,0 +1,9 @@
+# Test Plan: Checkmark Verification
+
+Verify the checkmark button appears and works correctly.
+
+## Steps
+1. Create this plan commit
+2. Check iPad shows green checkmark
+3. Tap checkmark → turns gray
+4. Push is allowed

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "enableAllProjectMcpServers": false,
+  "permissions": {
+    "defaultMode": "plan"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/RealtimeClaude/LogListView.swift
+++ b/RealtimeClaude/LogListView.swift
@@ -519,6 +519,7 @@ struct LogRowView: View {
 @Observable
 class DiffViewModel {
     var treeText: String = ""
+    var planAccepted: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -530,17 +531,58 @@ class DiffViewModel {
                 self.treeText = text
             }
             .store(in: &cancellables)
+
+        logger.planAcceptedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] accepted in
+                guard let self = self else { return }
+                self.planAccepted = accepted
+            }
+            .store(in: &cancellables)
     }
 
     var treeLines: [String] {
         guard !treeText.isEmpty else { return [] }
         return treeText.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
     }
+
+    var hasPlanCommit: Bool {
+        let pattern = #"\d+[smhd]\s+[a-f0-9]{7,8}\s+plan:"#
+        return treeText.range(of: pattern, options: .regularExpression) != nil
+    }
 }
 
 struct DiffView: View {
     @Binding var showDiff: Bool
     @Bindable var viewModel: DiffViewModel
+
+    var toggleItems: [ToggleBar.ToggleItem] {
+        var items: [ToggleBar.ToggleItem] = []
+
+        if viewModel.hasPlanCommit {
+            items.append(ToggleBar.ToggleItem(
+                color: viewModel.planAccepted ? .gray : .green,
+                isOn: .constant(false),
+                icon: "checkmark.circle.fill",
+                action: {
+                    if !viewModel.planAccepted {
+                        logger.sendAcceptPlan()
+                    }
+                }
+            ))
+        }
+
+        items.append(ToggleBar.ToggleItem(
+            color: .blue,
+            isOn: $showDiff,
+            icon: "xmark",
+            action: {
+                showDiff.toggle()
+            }
+        ))
+
+        return items
+    }
 
     var body: some View {
         ZStack {
@@ -579,16 +621,7 @@ struct DiffView: View {
             VStack {
                 Spacer()
 
-                ToggleBar(items: [
-                    ToggleBar.ToggleItem(
-                        color: .blue,
-                        isOn: $showDiff,
-                        icon: "xmark",
-                        action: {
-                            showDiff.toggle()
-                        }
-                    )
-                ])
+                ToggleBar(items: toggleItems)
             }
         }
     }

--- a/RealtimeClaude/Logger.swift
+++ b/RealtimeClaude/Logger.swift
@@ -21,10 +21,12 @@ protocol LoggerProtocol {
     var macConnectionReadySubject: CurrentValueSubject<Bool, Never> { get }
     var codeDiffSubject: CurrentValueSubject<String, Never> { get }
     var claudeIsActiveSubject: CurrentValueSubject<Bool, Never> { get }
+    var planAcceptedSubject: CurrentValueSubject<Bool, Never> { get }
 
     func sendPromptToMac(_ prompt: String, messageId: UUID)
     func sendAudioToMac(_ audioData: Data, isStart: Bool, isEnd: Bool, messageId: UUID?)
     func sendDeleteToMac(messageId: UUID)
+    func sendAcceptPlan()
 }
 
 enum LogType: Codable {
@@ -122,6 +124,7 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
     let macConnectionReadySubject = CurrentValueSubject<Bool, Never>(false)
     let codeDiffSubject = CurrentValueSubject<String, Never>("")
     let claudeIsActiveSubject = CurrentValueSubject<Bool, Never>(false)
+    let planAcceptedSubject = CurrentValueSubject<Bool, Never>(false)
 
     private var connection: NWConnection
     private let macHostname = "100.73.64.63"
@@ -136,16 +139,17 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
     private var reconnectTimer: DispatchSourceTimer?
 
     #if IS_TEST
-    private static let TEST_WORD = "MOONLIGHT"
+    private static let ACCEPT_PLAN_COMMAND = "ACCEPT_PLAN"
+    private static let CHECK_NOT_ACCEPTED_COMMAND = "CHECK_NOT_ACCEPTED"
 
     private static let TEST_0_MARKER = "✓ TEST[0] PASSED: handshake"
-    private static let TEST_1_MARKER = "✓ TEST[1] PASSED: claude_responds"
-    private static let TEST_2_MARKER = "✓ TEST[2] PASSED: recall_verified"
+    private static let TEST_1_MARKER = "✓ TEST[1] PASSED: plan_not_accepted"
+    private static let TEST_2_MARKER = "✓ TEST[2] PASSED: plan_accepted"
 
     private let STORY: [(command: String?, result: String)] = [
         (nil, Logger.TEST_0_MARKER),
-        ("Remember \(TEST_WORD)", Logger.TEST_1_MARKER),
-        ("What word did I ask you to remember?", Logger.TEST_2_MARKER)
+        (Logger.CHECK_NOT_ACCEPTED_COMMAND, Logger.TEST_1_MARKER),
+        (Logger.ACCEPT_PLAN_COMMAND, Logger.TEST_2_MARKER)
     ]
 
     private var storyIndex = 0
@@ -157,15 +161,20 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
         log(Logger.TEST_0_MARKER)
     }
 
-    func testClaudeRespondsPassed() {
+    func testPlanNotAccepted() {
         guard storyIndex == 1 else { return }
-        testsPassedSubject.send(testsPassedSubject.value + 1)
-        log(Logger.TEST_1_MARKER)
+        if planAcceptedSubject.value == false {
+            testsPassedSubject.send(testsPassedSubject.value + 1)
+            log(Logger.TEST_1_MARKER)
+            storyIndex += 1
+            advanceStory()
+        } else {
+            error("TEST[1] FAILED: planAccepted should be false but was true")
+        }
     }
 
-    func testRecallVerified(_ response: String) {
+    func testPlanAccepted() {
         guard storyIndex == 2 else { return }
-        guard !response.isEmpty else { return }
         testsPassedSubject.send(testsPassedSubject.value + 1)
         log(Logger.TEST_2_MARKER)
     }
@@ -225,15 +234,23 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
     #if !MANUAL_TESTING
     private func executeCommand(_ command: String) {
         pre(!command.isEmpty, "command must not be empty")
-        log("📤 Sending prompt to Mac: \(command)")
-        sendPromptToMac(command, messageId: UUID())
+        if command == Logger.CHECK_NOT_ACCEPTED_COMMAND {
+            log("📋 Checking planAccepted is false")
+            testPlanNotAccepted()
+        } else if command == Logger.ACCEPT_PLAN_COMMAND {
+            log("📤 Sending accept_plan to Mac")
+            sendAcceptPlan()
+        } else {
+            log("📤 Sending prompt to Mac: \(command)")
+            sendPromptToMac(command, messageId: UUID())
+        }
     }
     #endif
 
     #else
     func testHandshakePassed() {}
-    func testClaudeRespondsPassed() {}
-    func testRecallVerified(_ response: String) {}
+    func testPlanNotAccepted() {}
+    func testPlanAccepted() {}
     #endif
 
     private var isConnectionReady: Bool = false {
@@ -502,6 +519,8 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
             handleCodeDiffMessage(jsonData)
         case "claude_state":
             handleClaudeStateMessage(jsonData)
+        case "plan_accepted":
+            handlePlanAcceptedMessage(jsonData)
         default:
             error("Unexpected message type: \(messageType)")
         }
@@ -577,6 +596,10 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
         )
 
         sessionStatsSubject.send(sessionStats)
+
+        if let planAccepted = jsonData["planAccepted"] as? Bool {
+            planAcceptedSubject.send(planAccepted)
+        }
 
         log("Successful handshake: Session #\(sessionNumber), Total: \(totalUptime)ms, Today: \(todayUptime)ms, Logs: \(totalLogs)")
 
@@ -654,11 +677,6 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
 
         realtimeAPI.updatePrompt(messageId: messageId, text: prompt)
         realtimeAPI.updateSummary(messageId: messageId, text: summary)
-
-        #if IS_TEST
-        testClaudeRespondsPassed()
-        testRecallVerified(prompt)
-        #endif
     }
 
     private func handleCodeDiffMessage(_ jsonData: [String: Any]) {
@@ -680,6 +698,16 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
         log("📡 Claude state: \(isActive ? "active" : "inactive")")
         claudeIsActiveSubject.send(isActive)
         realtimeAPI.updateClaudeActiveState(isActive)
+    }
+
+    private func handlePlanAcceptedMessage(_ jsonData: [String: Any]) {
+        let branch = jsonData["branch"] as? String ?? "unknown"
+        log("📥 Plan accepted for branch: \(branch)")
+        planAcceptedSubject.send(true)
+
+        #if IS_TEST
+        testPlanAccepted()
+        #endif
     }
 
     private func sendStartMessage() {
@@ -746,6 +774,15 @@ private class Logger: @unchecked Sendable, LoggerProtocol {
         }
 
         sendMessage(jsonData, messageType: "delete", logMessage: "📤 [iOS → macOS] Sending delete for messageId: \(messageId.uuidString)")
+    }
+
+    func sendAcceptPlan() {
+        let msg: [String: Any] = ["type": "accept_plan"]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: msg) else {
+            error("Failed to serialize accept_plan message")
+            return
+        }
+        sendMessage(jsonData, messageType: "accept_plan", logMessage: "📤 [iOS → macOS] Sending accept_plan")
     }
 
     private func scheduleReconnect() {

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -41,6 +41,10 @@ xcrun devicectl device process terminate --device "$IPHONE_ID" ch.felix.realtime
 # Kill only test server (port 9999), leave production (8082) alone
 echo "Restarting test server on port 9999..."
 lsof -ti :9999 | xargs kill -9 2>/dev/null || true
+
+# Delete plan marker to ensure clean test state
+rm -f .plan-accepted
+
 sleep 1
 eval "$SERVER_FLAGS SERVER_PORT=9999 node scripts/mac-server.js >> /tmp/mac-server-test.log 2>&1 &"
 sleep 2

--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -869,6 +869,10 @@ function isDeleteMessage(logData) {
     return logData.type === 'delete';
 }
 
+function isAcceptPlanMessage(logData) {
+    return logData.type === 'accept_plan';
+}
+
 function handleDeleteMessage(logData) {
     const messageId = logData.messageId;
 
@@ -885,6 +889,46 @@ function handleDeleteMessage(logData) {
         log(`Marked message as deleted: ${messageId}`, 'handleDeleteMessage');
     } else {
         log(`No message state found for messageId: ${messageId}`, 'handleDeleteMessage');
+    }
+}
+
+function getCurrentBranchFromHead(repoPath) {
+    const headPath = path.join(repoPath, '.git', 'HEAD');
+    const headContent = fs.readFileSync(headPath, 'utf8').trim();
+    if (headContent.startsWith('ref: refs/heads/')) {
+        return headContent.replace('ref: refs/heads/', '');
+    }
+    return headContent;
+}
+
+function handleAcceptPlanMessage(socket, logData) {
+    log('Received accept_plan message', 'handleAcceptPlanMessage');
+
+    try {
+        const repoPath = getRepoPath();
+        if (!repoPath) {
+            error('No repo configured for accept_plan', 'handleAcceptPlanMessage');
+            return;
+        }
+
+        const branch = getCurrentBranchFromHead(repoPath);
+
+        const timestamp = Date.now();
+        const markerPath = path.join(repoPath, '.plan-accepted');
+        fs.writeFileSync(markerPath, `${branch}\n${timestamp}`);
+
+        log(`Wrote .plan-accepted with branch: ${branch}, timestamp: ${timestamp}`, 'handleAcceptPlanMessage');
+
+        const response = JSON.stringify({type: 'plan_accepted', branch: branch, timestamp: timestamp}) + '\n';
+        socket.write(response, (err) => {
+            if (err) {
+                error(`Failed to send plan_accepted response: ${err.message}`, 'handleAcceptPlanMessage');
+            } else {
+                log(`Sent plan_accepted response to iOS`, 'handleAcceptPlanMessage');
+            }
+        });
+    } catch (err) {
+        error(`Failed to handle accept_plan: ${err.message}`, 'handleAcceptPlanMessage');
     }
 }
 
@@ -961,6 +1005,8 @@ async function handleMessage(socket, logData) {
         await handleAudioMessage(socket, logData);
     } else if (isDeleteMessage(logData)) {
         handleDeleteMessage(logData);
+    } else if (isAcceptPlanMessage(logData)) {
+        handleAcceptPlanMessage(socket, logData);
     } else if (isErrorMessage(logData)) {
         handleErrorMessage(socket, logData);
     } else if (isLogMessage(logData)) {
@@ -1217,6 +1263,21 @@ function countLinesInContent(content) {
     return content.split('\n').filter(line => line.trim()).length;
 }
 
+function isPlanAccepted() {
+    const repoPath = getRepoPath();
+    if (!repoPath) return false;
+
+    const markerPath = path.join(repoPath, '.plan-accepted');
+    if (!fs.existsSync(markerPath)) return false;
+
+    const content = fs.readFileSync(markerPath, 'utf8').trim();
+    const acceptedBranch = content.split('\n')[0];
+
+    const currentBranch = getCurrentBranchFromHead(repoPath);
+
+    return acceptedBranch === currentBranch;
+}
+
 async function sendHandshakeResponse(socket, stats) {
     let apiKey;
     if (IS_TEST) {
@@ -1226,6 +1287,7 @@ async function sendHandshakeResponse(socket, stats) {
     }
 
     const previousErrors = getPreviousSessionErrors(stats.sessionNumber);
+    const planAccepted = isPlanAccepted();
 
     const crypto = require('crypto');
     const handshakeMessageId = lastSentAssistantMessage ? crypto.randomUUID() : null;
@@ -1240,7 +1302,8 @@ async function sendHandshakeResponse(socket, stats) {
         previousErrors: previousErrors,
         currentAssistantMessage: lastSentAssistantMessage,
         currentAssistantMessageSummary: "",
-        messageId: handshakeMessageId
+        messageId: handshakeMessageId,
+        planAccepted: planAccepted
     }) + '\n';
 
     socket.write(handshakeResponse);


### PR DESCRIPTION
## Summary
- Checkmark button only appears when there's an unpushed `plan:` commit
- Green when plan not accepted, gray after acceptance  
- Tapping sends `accept_plan` to Mac → writes `.plan-accepted` → responds `plan_accepted`
- STORY tests verify the full handshake → not_accepted → accepted flow

## Test plan
- [x] Automated tests pass (STORY flow)
- [x] Manual test: checkmark appears, turns gray on tap
- [x] Push allowed after acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)