### PR TITLE
inject: bump post-keystroke pre-Enter delay to 2 s

### DIFF
--- a/scripts/mac-server.js
+++ b/scripts/mac-server.js
@@ -2203,7 +2203,7 @@ tell application "System Events"
 
         keystroke "${escapedPrompt}"
 
-        delay 1
+        delay 2
 
         key code 36
 


### PR DESCRIPTION
## Summary

Single-line change in `scripts/mac-server.js`, inside the `injectIntoTerminal` AppleScript template: doubles the `delay` between `keystroke \"\${escapedPrompt}\"` and `key code 36` (Return) from 1 s to 2 s.

```diff
         keystroke "\${escapedPrompt}"

-        delay 1
+        delay 2

         key code 36
```

## Why

Under load (long prompts, busy CPU), 1 s was tight enough that Enter could fire before Terminal finished consuming the keystroke buffer, producing a truncated submission. 2 s gives a comfortable margin without hurting interactive feel meaningfully.

## Live / dormant status of the patched file

**Dormant in this workspace.** `ps auxww | grep mac-server.js` and `launchctl list | grep -iE 'mac-server|realtime'` both come back empty — no node process is currently running this script, and there is no launchd job that owns it. The path `~/.openclaw/workspace/tmp/realtime-claude/scripts/...` is a workspace copy of this repo, not a live service on the host where the PR was prepared.

This means:
- No restart is required for this change in the workspace.
- On any host where `scripts/mac-server.js` IS run as a service (the production realtime-claude deployment), pulling the merged change and bouncing the node process is required for the new delay to take effect, because the AppleScript string is captured once when the module evaluates.

## Test plan

- [x] `node -c scripts/mac-server.js` → syntax OK (parser exit 0).
- [x] No live process to interrupt — pure source edit; pull + restart on the production host once merged.
- [ ] Validate end-to-end on the production realtime-claude host by triggering one injection and confirming the Enter fires after ~2 s rather than ~1 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)